### PR TITLE
Adjust DB config to use separate env vars

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,7 +4,11 @@ NODE_ENV=development
 FRONTEND_URL=http://localhost:3000
 
 # Configurações do Banco de Dados
-DATABASE_URL="postgres://postgres:2412055aa@easypanel.zapchatbr.com:5432/vigilancia?sslmode=disable"
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=zapchat_tur
+DB_USER=postgres
+DB_PASSWORD=password
 
 # Configurações JWT
 JWT_SECRET=your-super-secret-jwt-key-here

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,3 +1,4 @@
+import '../src/loadEnv';
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,8 @@
+import './loadEnv';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
-import dotenv from 'dotenv';
 import { PrismaClient } from '@prisma/client';
 
 // Importar rotas
@@ -10,8 +10,6 @@ import authRoutes from './routes/auth';
 import gameRoutes from './routes/games';
 import rtpRoutes from './routes/rtp';
 
-// Carregar variáveis de ambiente
-dotenv.config();
 
 const app = express();
 const PORT = parseInt(process.env.PORT || '3001');

--- a/backend/src/loadEnv.ts
+++ b/backend/src/loadEnv.ts
@@ -1,0 +1,10 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+if (!process.env.DATABASE_URL) {
+  const { DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD } = process.env;
+  if (DB_HOST && DB_PORT && DB_NAME && DB_USER && DB_PASSWORD) {
+    process.env.DATABASE_URL = `postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`;
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,11 @@ services:
     environment:
       NODE_ENV: production
       PORT: 3001
-      DATABASE_URL: postgres://postgres:2412055aa@easypanel.zapchatbr.com:5432/vigilancia?sslmode=disable
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_NAME: zapchat_tur
+      DB_USER: postgres
+      DB_PASSWORD: password
       JWT_SECRET: rtp-games-dashboard-super-secret-jwt-key-2024
       JWT_EXPIRES_IN: 7d
       BCRYPT_ROUNDS: 12
@@ -25,8 +29,9 @@ services:
       - ./backend/prisma:/app/prisma
     command: >
       sh -c "
-        npx prisma migrate deploy &&
-        npx prisma db seed &&
+        export DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=disable && \
+        npx prisma migrate deploy && \
+        npx prisma db seed && \
         npm start
       "
 


### PR DESCRIPTION
## Summary
- update env example to use DB_HOST, DB_PORT, DB_NAME, DB_USER and DB_PASSWORD
- generate DATABASE_URL dynamically via new `loadEnv.ts`
- load env variables before importing Prisma in the API server
- update seed script to load env vars
- adjust docker-compose to use new DB_* vars and build DATABASE_URL in the start command

## Testing
- `npm run build` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ff6a8fb60832eb0d24cb1fa362211