### PR TITLE
Fix Prisma binary target for Node 20

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["linux-musl-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- specify `linux-musl-openssl-3.0.x` binary target for Prisma

## Testing
- `npm run prisma:generate` *(fails: `prisma: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ffd57f874832eb15a69d97ced79b0