### PR TITLE
Add betting house support

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ npm run lint         # Linter
 - `GET /api/rtp/games/:id/history` - Histórico do jogo
 - `DELETE /api/rtp/:id` - Deletar registro
 
+### Betting Houses
+- `POST /api/houses` - Criar casa de aposta
+- `GET /api/houses` - Listar casas de aposta
+- `GET /api/houses/:id` - Detalhes da casa de aposta
+- `PUT /api/houses/:id` - Atualizar casa de aposta
+- `DELETE /api/houses/:id` - Remover casa de aposta
+
 ## 🐛 Troubleshooting
 
 ### Problemas Comuns

--- a/backend/src/controllers/bettingHouseController.ts
+++ b/backend/src/controllers/bettingHouseController.ts
@@ -1,0 +1,117 @@
+import { Request, Response } from 'express';
+import { BettingHouse } from '../models/bettingHouse';
+
+export const createBettingHouse = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { name, apiName, apiUrl, updateInterval, currency } = req.body;
+
+    if (!name || !apiName || !apiUrl || !updateInterval || !currency) {
+      res.status(400).json({
+        error: 'Todos os campos são obrigatórios',
+        code: 'MISSING_FIELDS'
+      });
+      return;
+    }
+
+    const house = await BettingHouse.create({
+      name,
+      apiName,
+      apiUrl,
+      updateInterval,
+      currency
+    });
+
+    res.status(201).json(house);
+  } catch (error) {
+    console.error('Erro ao criar casa de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};
+
+export const listBettingHouses = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const houses = await BettingHouse.findAll();
+    res.json(houses);
+  } catch (error) {
+    console.error('Erro ao listar casas de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};
+
+export const getBettingHouse = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const house = await BettingHouse.findByPk(id);
+
+    if (!house) {
+      res.status(404).json({
+        error: 'Casa de aposta não encontrada',
+        code: 'NOT_FOUND'
+      });
+      return;
+    }
+
+    res.json(house);
+  } catch (error) {
+    console.error('Erro ao obter casa de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};
+
+export const updateBettingHouse = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const house = await BettingHouse.findByPk(id);
+
+    if (!house) {
+      res.status(404).json({
+        error: 'Casa de aposta não encontrada',
+        code: 'NOT_FOUND'
+      });
+      return;
+    }
+
+    const { name, apiName, apiUrl, updateInterval, currency } = req.body;
+    await house.update({ name, apiName, apiUrl, updateInterval, currency });
+    res.json(house);
+  } catch (error) {
+    console.error('Erro ao atualizar casa de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};
+
+export const deleteBettingHouse = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const house = await BettingHouse.findByPk(id);
+
+    if (!house) {
+      res.status(404).json({
+        error: 'Casa de aposta não encontrada',
+        code: 'NOT_FOUND'
+      });
+      return;
+    }
+
+    await house.destroy();
+    res.status(204).send();
+  } catch (error) {
+    console.error('Erro ao deletar casa de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import sequelize from './models';
 
 // Importar rotas
 import authRoutes from './routes/auth';
+import bettingHouseRoutes from './routes/bettingHouse';
 
 
 const app = express();
@@ -34,6 +35,7 @@ app.use(express.urlencoded({ extended: true }));
 
 // Rotas
 app.use('/api/auth', authRoutes);
+app.use('/api/houses', bettingHouseRoutes);
 
 // Rota de health check
 app.get('/api/health', (req, res) => {

--- a/backend/src/models/bettingHouse.ts
+++ b/backend/src/models/bettingHouse.ts
@@ -1,0 +1,63 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize from './index';
+
+interface BettingHouseAttributes {
+  id: number;
+  name: string;
+  apiName: string;
+  apiUrl: string;
+  updateInterval: number;
+  currency: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+interface BettingHouseCreationAttributes extends Optional<BettingHouseAttributes, 'id'> {}
+
+export class BettingHouse extends Model<BettingHouseAttributes, BettingHouseCreationAttributes>
+  implements BettingHouseAttributes {
+  public id!: number;
+  public name!: string;
+  public apiName!: string;
+  public apiUrl!: string;
+  public updateInterval!: number;
+  public currency!: string;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+BettingHouse.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    apiName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    apiUrl: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    updateInterval: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    currency: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdAt: DataTypes.DATE,
+    updatedAt: DataTypes.DATE,
+  },
+  {
+    sequelize,
+    tableName: 'betting_houses',
+  }
+);

--- a/backend/src/routes/bettingHouse.ts
+++ b/backend/src/routes/bettingHouse.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import {
+  createBettingHouse,
+  listBettingHouses,
+  getBettingHouse,
+  updateBettingHouse,
+  deleteBettingHouse
+} from '../controllers/bettingHouseController';
+import { authenticateToken } from '../middleware/auth';
+
+const router = Router();
+
+router.post('/', authenticateToken, createBettingHouse);
+router.get('/', authenticateToken, listBettingHouses);
+router.get('/:id', authenticateToken, getBettingHouse);
+router.put('/:id', authenticateToken, updateBettingHouse);
+router.delete('/:id', authenticateToken, deleteBettingHouse);
+
+export default router;


### PR DESCRIPTION
## Summary
- model betting houses in Sequelize
- implement CRUD controller and routes
- mount house routes in backend index
- document betting house endpoints

## Testing
- `npm run build` *(fails: cannot fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_687120795b4c832eb35f7f4631fba765