### PR TITLE
Add betting house support

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ npm run lint         # Linter
 - `GET /api/rtp/games/:id/history` - Histórico do jogo
 - `DELETE /api/rtp/:id` - Deletar registro
 
+### Betting Houses
+- `POST /api/houses` - Criar casa de aposta
+- `GET /api/houses` - Listar casas de aposta
+- `GET /api/houses/:id` - Detalhes da casa de aposta
+- `PUT /api/houses/:id` - Atualizar casa de aposta
+- `DELETE /api/houses/:id` - Remover casa de aposta
+
 ## 🐛 Troubleshooting
 
 ### Problemas Comuns

--- a/backend/src/controllers/bettingHouseController.ts
+++ b/backend/src/controllers/bettingHouseController.ts
@@ -1,0 +1,117 @@
+import { Request, Response } from 'express';
+import { BettingHouse } from '../models/bettingHouse';
+
+export const createBettingHouse = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { name, apiName, apiUrl, updateInterval, currency } = req.body;
+
+    if (!name || !apiName || !apiUrl || !updateInterval || !currency) {
+      res.status(400).json({
+        error: 'Todos os campos são obrigatórios',
+        code: 'MISSING_FIELDS'
+      });
+      return;
+    }
+
+    const house = await BettingHouse.create({
+      name,
+      apiName,
+      apiUrl,
+      updateInterval,
+      currency
+    });
+
+    res.status(201).json(house);
+  } catch (error) {
+    console.error('Erro ao criar casa de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};
+
+export const listBettingHouses = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const houses = await BettingHouse.findAll();
+    res.json(houses);
+  } catch (error) {
+    console.error('Erro ao listar casas de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};
+
+export const getBettingHouse = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const house = await BettingHouse.findByPk(id);
+
+    if (!house) {
+      res.status(404).json({
+        error: 'Casa de aposta não encontrada',
+        code: 'NOT_FOUND'
+      });
+      return;
+    }
+
+    res.json(house);
+  } catch (error) {
+    console.error('Erro ao obter casa de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};
+
+export const updateBettingHouse = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const house = await BettingHouse.findByPk(id);
+
+    if (!house) {
+      res.status(404).json({
+        error: 'Casa de aposta não encontrada',
+        code: 'NOT_FOUND'
+      });
+      return;
+    }
+
+    const { name, apiName, apiUrl, updateInterval, currency } = req.body;
+    await house.update({ name, apiName, apiUrl, updateInterval, currency });
+    res.json(house);
+  } catch (error) {
+    console.error('Erro ao atualizar casa de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};
+
+export const deleteBettingHouse = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const house = await BettingHouse.findByPk(id);
+
+    if (!house) {
+      res.status(404).json({
+        error: 'Casa de aposta não encontrada',
+        code: 'NOT_FOUND'
+      });
+      return;
+    }
+
+    await house.destroy();
+    res.status(204).send();
+  } catch (error) {
+    console.error('Erro ao deletar casa de aposta:', error);
+    res.status(500).json({
+      error: 'Erro interno do servidor',
+      code: 'INTERNAL_ERROR'
+    });
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import sequelize from './models';
 
 // Importar rotas
 import authRoutes from './routes/auth';
+import bettingHouseRoutes from './routes/bettingHouse';
 
 
 const app = express();
@@ -34,6 +35,7 @@ app.use(express.urlencoded({ extended: true }));
 
 // Rotas
 app.use('/api/auth', authRoutes);
+app.use('/api/houses', bettingHouseRoutes);
 
 // Rota de health check
 app.get('/api/health', (req, res) => {

--- a/backend/src/models/bettingHouse.ts
+++ b/backend/src/models/bettingHouse.ts
@@ -1,0 +1,63 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize from './index';
+
+interface BettingHouseAttributes {
+  id: number;
+  name: string;
+  apiName: string;
+  apiUrl: string;
+  updateInterval: number;
+  currency: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+interface BettingHouseCreationAttributes extends Optional<BettingHouseAttributes, 'id'> {}
+
+export class BettingHouse extends Model<BettingHouseAttributes, BettingHouseCreationAttributes>
+  implements BettingHouseAttributes {
+  public id!: number;
+  public name!: string;
+  public apiName!: string;
+  public apiUrl!: string;
+  public updateInterval!: number;
+  public currency!: string;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+BettingHouse.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    apiName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    apiUrl: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    updateInterval: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    currency: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdAt: DataTypes.DATE,
+    updatedAt: DataTypes.DATE,
+  },
+  {
+    sequelize,
+    tableName: 'betting_houses',
+  }
+);

--- a/backend/src/routes/bettingHouse.ts
+++ b/backend/src/routes/bettingHouse.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import {
+  createBettingHouse,
+  listBettingHouses,
+  getBettingHouse,
+  updateBettingHouse,
+  deleteBettingHouse
+} from '../controllers/bettingHouseController';
+import { authenticateToken } from '../middleware/auth';
+
+const router = Router();
+
+router.post('/', authenticateToken, createBettingHouse);
+router.get('/', authenticateToken, listBettingHouses);
+router.get('/:id', authenticateToken, getBettingHouse);
+router.put('/:id', authenticateToken, updateBettingHouse);
+router.delete('/:id', authenticateToken, deleteBettingHouse);
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import HomePage from './pages/Home'
 import LoginPage from './pages/login/Login'
 import RegisterPage from './pages/register/Register'
 import DashboardPage from './pages/dashboard/Dashboard'
+import HousesPage from './pages/houses/Houses'
 import Layout from './components/layout/Layout'
 
 export default function App() {
@@ -17,6 +18,14 @@ export default function App() {
         element={
           <Layout>
             <DashboardPage />
+          </Layout>
+        }
+      />
+      <Route
+        path="/houses"
+        element={
+          <Layout>
+            <HousesPage />
           </Layout>
         }
       />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -35,6 +35,12 @@ export default function Header() {
                 Jogos
               </Link>
               <Link
+                href="/houses"
+                className="text-secondary-600 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium transition-colors"
+              >
+                Casas
+              </Link>
+              <Link
                 href="/rtp-history"
                 className="text-secondary-600 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium transition-colors"
               >

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -115,6 +115,34 @@ export const rtpApi = {
     api.delete(`/rtp/${id}`),
 }
 
+// Funções de casas de aposta
+export const housesApi = {
+  create: (data: {
+    name: string
+    apiName: string
+    apiUrl: string
+    updateInterval: number
+    currency: string
+  }) => api.post('/houses', data),
+
+  getAll: () => api.get('/houses'),
+
+  getById: (id: number) => api.get(`/houses/${id}`),
+
+  update: (
+    id: number,
+    data: {
+      name: string
+      apiName: string
+      apiUrl: string
+      updateInterval: number
+      currency: string
+    }
+  ) => api.put(`/houses/${id}`, data),
+
+  remove: (id: number) => api.delete(`/houses/${id}`),
+}
+
 // Função para verificar se a API está online
 export const checkApiHealth = async (): Promise<boolean> => {
   try {

--- a/frontend/src/pages/houses/Houses.tsx
+++ b/frontend/src/pages/houses/Houses.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import Layout from '@/components/layout/Layout'
+import { Card, CardHeader, CardContent } from '@/components/ui/Card'
+import Input from '@/components/ui/Input'
+import Button from '@/components/ui/Button'
+import { housesApi } from '@/lib/api'
+import { BettingHouse } from '@/types'
+
+interface HouseFormData {
+  name: string
+  apiName: string
+  apiUrl: string
+  updateInterval: number
+  currency: string
+}
+
+export default function HousesPage() {
+  const [houses, setHouses] = useState<BettingHouse[]>([])
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<HouseFormData>()
+
+  const loadHouses = async () => {
+    try {
+      const res = await housesApi.getAll()
+      setHouses(res.data)
+    } catch {
+      setError('Erro ao carregar casas de aposta')
+    }
+  }
+
+  useEffect(() => {
+    loadHouses()
+  }, [])
+
+  const onSubmit = async (data: HouseFormData) => {
+    try {
+      setLoading(true)
+      if (editingId) {
+        await housesApi.update(editingId, data)
+      } else {
+        await housesApi.create(data)
+      }
+      reset()
+      setEditingId(null)
+      await loadHouses()
+    } catch {
+      setError('Erro ao salvar casa de aposta')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleEdit = (house: BettingHouse) => {
+    setEditingId(house.id)
+    reset({
+      name: house.name,
+      apiName: house.apiName,
+      apiUrl: house.apiUrl,
+      updateInterval: house.updateInterval,
+      currency: house.currency,
+    })
+  }
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Deseja remover esta casa de aposta?')) return
+    try {
+      await housesApi.remove(id)
+      await loadHouses()
+    } catch {
+      setError('Erro ao remover casa de aposta')
+    }
+  }
+
+  const cancelEdit = () => {
+    reset()
+    setEditingId(null)
+  }
+
+  return (
+    <Layout>
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <h3 className="text-lg font-medium text-secondary-900">
+              {editingId ? 'Editar Casa de Aposta' : 'Nova Casa de Aposta'}
+            </h3>
+          </CardHeader>
+          <CardContent>
+            {error && (
+              <div className="mb-4 bg-error-50 border border-error-200 text-error-700 px-4 py-3 rounded-md">
+                {error}
+              </div>
+            )}
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+              <Input label="Nome" error={errors.name?.message} {...register('name', { required: true })} />
+              <Input label="API Name" error={errors.apiName?.message} {...register('apiName', { required: true })} />
+              <Input label="API URL" error={errors.apiUrl?.message} {...register('apiUrl', { required: true })} />
+              <Input label="Intervalo (minutos)" type="number" error={errors.updateInterval?.message} {...register('updateInterval', { required: true, valueAsNumber: true })} />
+              <Input label="Moeda" error={errors.currency?.message} {...register('currency', { required: true })} />
+              <div className="flex space-x-2">
+                <Button type="submit" loading={loading}>
+                  {editingId ? 'Salvar' : 'Adicionar'}
+                </Button>
+                {editingId && (
+                  <Button type="button" variant="ghost" onClick={cancelEdit}>
+                    Cancelar
+                  </Button>
+                )}
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <h3 className="text-lg font-medium text-secondary-900">Casas de Aposta</h3>
+          </CardHeader>
+          <CardContent>
+            {houses.length === 0 ? (
+              <p className="text-secondary-600">Nenhuma casa de aposta cadastrada.</p>
+            ) : (
+              <table className="min-w-full divide-y divide-secondary-200 text-sm">
+                <thead>
+                  <tr>
+                    <th className="px-4 py-2 text-left">Nome</th>
+                    <th className="px-4 py-2 text-left">API Name</th>
+                    <th className="px-4 py-2 text-left">URL</th>
+                    <th className="px-4 py-2 text-left">Intervalo</th>
+                    <th className="px-4 py-2 text-left">Moeda</th>
+                    <th className="px-4 py-2" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-secondary-200">
+                  {houses.map((house) => (
+                    <tr key={house.id}>
+                      <td className="px-4 py-2">{house.name}</td>
+                      <td className="px-4 py-2">{house.apiName}</td>
+                      <td className="px-4 py-2">{house.apiUrl}</td>
+                      <td className="px-4 py-2">{house.updateInterval}</td>
+                      <td className="px-4 py-2">{house.currency}</td>
+                      <td className="px-4 py-2 space-x-2">
+                        <Button size="sm" variant="outline" onClick={() => handleEdit(house)}>
+                          Editar
+                        </Button>
+                        <Button size="sm" variant="danger" onClick={() => handleDelete(house.id)}>
+                          Remover
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  )
+}
+

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -60,6 +60,18 @@ export interface GameStats {
   }>
 }
 
+// Tipos de casas de aposta
+export interface BettingHouse {
+  id: number
+  name: string
+  apiName: string
+  apiUrl: string
+  updateInterval: number
+  currency: string
+  createdAt: string
+  updatedAt: string
+}
+
 // Tipos de RTP
 export interface RtpRecord {
   id: number


### PR DESCRIPTION
## Summary
- model betting houses in Sequelize
- implement CRUD controller and routes
- mount house routes in backend index
- document betting house endpoints
- add betting house management UI

## Testing
- `npm run build` *(fails: cannot find modules)*
- `npm run build` in frontend *(fails: vite not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687120795b4c832eb35f7f4631fba765