### PR TITLE
Remove double header in houses page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,7 @@
 - Atualizar dependências, corrigir bugs e implementar melhorias conforme solicitado.
 - Gerenciar e manter consistência entre frontend React e backend Node.
 - Executar testes e lint sempre que possível antes de finalizar mudanças.
+- Evitar duplicar componentes de layout; as páginas que já são embrulhadas pelo
+  `Layout` nas rotas não devem importá-lo novamente. Isso previne headers
+  duplicados.
 

--- a/frontend/src/pages/houses/Houses.tsx
+++ b/frontend/src/pages/houses/Houses.tsx
@@ -86,8 +86,7 @@ export default function HousesPage() {
   }
 
   return (
-    <Layout>
-      <div className="space-y-6">
+    <div className="space-y-6">
         <Card>
           <CardHeader>
             <h3 className="text-lg font-medium text-secondary-900">
@@ -163,7 +162,6 @@ export default function HousesPage() {
           </CardContent>
         </Card>
       </div>
-    </Layout>
-  )
+    )
 }
 


### PR DESCRIPTION
## Summary
- fix double layout usage on Houses page
- document layout rule in AGENTS guidelines

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_687128274774832eaf2dcd58c7f02e07