### PR TITLE
Add forest theme option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 ### Histórico de Alterações
 
 - 2025-07-11: Ajustado link de navegação para "/houses" no Header do frontend para usar `to` em vez de `href`.
+- 2025-07-12: Adicionada opção de tema "Floresta" com paleta personalizada.
 
 ## Estrutura de Banco de Dados
 

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -17,6 +17,7 @@ export default function ThemeToggle() {
       <option value="light">Claro</option>
       <option value="dark">Escuro</option>
       <option value="system">Sistema</option>
+      <option value="forest">Floresta</option>
     </select>
   )
 }

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -12,6 +12,11 @@
   --foreground: #ffffff;
 }
 
+.forest {
+  --background: linear-gradient(to bottom, #e6f4ea, #2c5f2d);
+  --foreground: #043f1c;
+}
+
 body {
   color: var(--foreground);
   background: var(--background);

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react'
 
-export type Theme = 'light' | 'dark' | 'system'
+export type Theme = 'light' | 'dark' | 'system' | 'forest'
 
 interface ThemeContextProps {
   theme: Theme
@@ -14,10 +14,12 @@ function applyTheme(theme: Theme) {
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
   const resolved = theme === 'system' ? (prefersDark ? 'dark' : 'light') : theme
 
+  root.classList.remove('dark', 'forest')
+
   if (resolved === 'dark') {
     root.classList.add('dark')
-  } else {
-    root.classList.remove('dark')
+  } else if (resolved === 'forest') {
+    root.classList.add('forest')
   }
 }
 
@@ -26,7 +28,12 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const saved = localStorage.getItem('theme') as Theme | null
-    if (saved === 'light' || saved === 'dark' || saved === 'system') {
+    if (
+      saved === 'light' ||
+      saved === 'dark' ||
+      saved === 'system' ||
+      saved === 'forest'
+    ) {
       setThemeState(saved)
       applyTheme(saved)
     } else {


### PR DESCRIPTION
## Summary
- allow selecting a `forest` theme
- set background and foreground for the new theme
- persist new theme selection in localStorage
- document theming change in `AGENTS.md`

## Testing
- `yarn lint` *(fails: package not present)*
- `yarn type-check` *(fails: package not present)*

------
https://chatgpt.com/codex/tasks/task_e_68712c226668832eba175e93265fe64e