### PR TITLE
Implement seconds support for betting house intervals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 
 - 2025-07-11: Ajustado link de navegação para "/houses" no Header do frontend para usar `to` em vez de `href`.
 - 2025-07-12: Adicionada opção de tema "Floresta" com paleta personalizada.
+- 2025-07-13: Adicionado campo `updateIntervalUnit` em `betting_houses` para definir se o intervalo está em segundos ou minutos.
 
 ## Estrutura de Banco de Dados
 

--- a/backend/database/migrations/002_add_update_interval_unit.sql
+++ b/backend/database/migrations/002_add_update_interval_unit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "betting_houses" ADD COLUMN "updateIntervalUnit" VARCHAR(10) NOT NULL DEFAULT 'seconds';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.6.8",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -394,6 +395,12 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -402,6 +409,17 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -680,6 +698,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -794,6 +824,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -970,6 +1009,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1117,6 +1171,26 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1132,6 +1206,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1333,6 +1423,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2123,6 +2228,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,8 @@
     "jsonwebtoken": "^9.0.2",
     "sequelize": "^6.37.1",
     "pg": "^8.11.3",
-    "pg-hstore": "^2.3.4"
+    "pg-hstore": "^2.3.4",
+    "axios": "^1.6.8"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/backend/src/controllers/bettingHouseController.ts
+++ b/backend/src/controllers/bettingHouseController.ts
@@ -3,9 +3,9 @@ import { BettingHouse } from '../models/bettingHouse';
 
 export const createBettingHouse = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { name, apiName, apiUrl, updateInterval, currency } = req.body;
+    const { name, apiName, apiUrl, updateInterval, updateIntervalUnit, currency } = req.body;
 
-    if (!name || !apiName || !apiUrl || !updateInterval || !currency) {
+    if (!name || !apiName || !apiUrl || !updateInterval || !updateIntervalUnit || !currency) {
       res.status(400).json({
         error: 'Todos os campos são obrigatórios',
         code: 'MISSING_FIELDS'
@@ -18,6 +18,7 @@ export const createBettingHouse = async (req: Request, res: Response): Promise<v
       apiName,
       apiUrl,
       updateInterval,
+      updateIntervalUnit,
       currency
     });
 
@@ -80,8 +81,8 @@ export const updateBettingHouse = async (req: Request, res: Response): Promise<v
       return;
     }
 
-    const { name, apiName, apiUrl, updateInterval, currency } = req.body;
-    await house.update({ name, apiName, apiUrl, updateInterval, currency });
+    const { name, apiName, apiUrl, updateInterval, updateIntervalUnit, currency } = req.body;
+    await house.update({ name, apiName, apiUrl, updateInterval, updateIntervalUnit, currency });
     res.json(house);
   } catch (error) {
     console.error('Erro ao atualizar casa de aposta:', error);

--- a/backend/src/models/bettingHouse.ts
+++ b/backend/src/models/bettingHouse.ts
@@ -7,6 +7,7 @@ interface BettingHouseAttributes {
   apiName: string;
   apiUrl: string;
   updateInterval: number;
+  updateIntervalUnit: 'seconds' | 'minutes';
   currency: string;
   createdAt?: Date;
   updatedAt?: Date;
@@ -21,6 +22,7 @@ export class BettingHouse extends Model<BettingHouseAttributes, BettingHouseCrea
   public apiName!: string;
   public apiUrl!: string;
   public updateInterval!: number;
+  public updateIntervalUnit!: 'seconds' | 'minutes';
   public currency!: string;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
@@ -48,6 +50,11 @@ BettingHouse.init(
     updateInterval: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    updateIntervalUnit: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'seconds',
     },
     currency: {
       type: DataTypes.STRING,

--- a/backend/src/utils/rtpFetcher.ts
+++ b/backend/src/utils/rtpFetcher.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+export async function fetchRtpData(url: string) {
+  const res = await axios.get(url, {
+    headers: {
+      accept: 'application/x-protobuf',
+      'content-type': 'application/x-protobuf'
+    },
+    responseType: 'arraybuffer'
+  })
+  return res.data
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -122,6 +122,7 @@ export const housesApi = {
     apiName: string
     apiUrl: string
     updateInterval: number
+    updateIntervalUnit: 'seconds' | 'minutes'
     currency: string
   }) => api.post('/houses', data),
 
@@ -136,6 +137,7 @@ export const housesApi = {
       apiName: string
       apiUrl: string
       updateInterval: number
+      updateIntervalUnit: 'seconds' | 'minutes'
       currency: string
     }
   ) => api.put(`/houses/${id}`, data),

--- a/frontend/src/pages/houses/Houses.tsx
+++ b/frontend/src/pages/houses/Houses.tsx
@@ -11,6 +11,7 @@ interface HouseFormData {
   apiName: string
   apiUrl: string
   updateInterval: number
+  updateIntervalUnit: 'seconds' | 'minutes'
   currency: string
 }
 
@@ -65,6 +66,7 @@ export default function HousesPage() {
       apiName: house.apiName,
       apiUrl: house.apiUrl,
       updateInterval: house.updateInterval,
+      updateIntervalUnit: house.updateIntervalUnit,
       currency: house.currency,
     })
   }
@@ -102,7 +104,25 @@ export default function HousesPage() {
               <Input label="Nome" error={errors.name?.message} {...register('name', { required: true })} />
               <Input label="API Name" error={errors.apiName?.message} {...register('apiName', { required: true })} />
               <Input label="API URL" error={errors.apiUrl?.message} {...register('apiUrl', { required: true })} />
-              <Input label="Intervalo (minutos)" type="number" error={errors.updateInterval?.message} {...register('updateInterval', { required: true, valueAsNumber: true })} />
+              <div className="flex space-x-2">
+                <Input
+                  label="Intervalo"
+                  type="number"
+                  className="flex-1"
+                  error={errors.updateInterval?.message}
+                  {...register('updateInterval', { required: true, valueAsNumber: true })}
+                />
+                <div className="w-32">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Unidade</label>
+                  <select
+                    className="h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                    {...register('updateIntervalUnit', { required: true })}
+                  >
+                    <option value="seconds">Segundos</option>
+                    <option value="minutes">Minutos</option>
+                  </select>
+                </div>
+              </div>
               <Input label="Moeda" error={errors.currency?.message} {...register('currency', { required: true })} />
               <div className="flex space-x-2">
                 <Button type="submit" loading={loading}>
@@ -143,7 +163,9 @@ export default function HousesPage() {
                       <td className="px-4 py-2">{house.name}</td>
                       <td className="px-4 py-2">{house.apiName}</td>
                       <td className="px-4 py-2">{house.apiUrl}</td>
-                      <td className="px-4 py-2">{house.updateInterval}</td>
+                      <td className="px-4 py-2">
+                        {house.updateInterval} {house.updateIntervalUnit === 'seconds' ? 's' : 'min'}
+                      </td>
                       <td className="px-4 py-2">{house.currency}</td>
                       <td className="px-4 py-2 space-x-2">
                         <Button size="sm" variant="outline" onClick={() => handleEdit(house)}>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -67,6 +67,7 @@ export interface BettingHouse {
   apiName: string
   apiUrl: string
   updateInterval: number
+  updateIntervalUnit: 'seconds' | 'minutes'
   currency: string
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
## Summary
- add `updateIntervalUnit` database column and model property
- handle new field in betting house controller and frontend forms
- display unit in houses table
- add protobuf headers helper for RTP fetching

## Testing
- `npm run build` in `backend`
- `npm install` & `npm run lint` *(fails: ESLint couldn't find config next/core-web-vitals)*
- `npm run type-check` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_68713024d044832ca517f4fa32497a5b