### PR TITLE
Update frontend for dynamic RTP updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ npm run dev
 cd frontend
 npm install
 cp .env.local.example .env.local
-# Configure as variáveis no .env.local
+# Configure as variáveis no .env.local (VITE_API_URL e VITE_WS_URL)
 npm run dev
 ```
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:3001/api
+VITE_WS_URL=ws://localhost:3001/ws

--- a/frontend/src/hooks/useRtpSocket.tsx
+++ b/frontend/src/hooks/useRtpSocket.tsx
@@ -19,7 +19,9 @@ export function useRtpSocket() {
   const [updates, setUpdates] = useState<RtpUpdate[]>([])
 
   useEffect(() => {
-    const ws = new WebSocket('ws://localhost:3001/ws')
+    const wsUrl =
+      (import.meta as any).env.VITE_WS_URL || 'ws://localhost:3001/ws'
+    const ws = new WebSocket(wsUrl)
 
     ws.onmessage = (event) => {
       try {
@@ -29,7 +31,13 @@ export function useRtpSocket() {
             ...u,
             rtp: adjustRtp(u.rtp),
           }))
-          setUpdates(adjusted)
+          setUpdates((prev) => {
+            const map = new Map(prev.map((u) => [`${u.houseId}:${u.gameName}`, u]))
+            adjusted.forEach((u) => {
+              map.set(`${u.houseId}:${u.gameName}`, u)
+            })
+            return Array.from(map.values())
+          })
         }
       } catch {
         // ignore

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
 // Configuração base da API
-const API_BASE_URL = 'https://rtp-api.zapchatbr.com/api'
-//const API_BASE_URL = 'http://localhost:3001/api'
+const API_BASE_URL =
+  (import.meta as any).env.VITE_API_URL || 'http://localhost:3001/api'
 
 // Criar instância do axios
 export const api = axios.create({


### PR DESCRIPTION
## Summary
- make API and WebSocket URLs configurable through environment variables
- handle multiple betting house RTP updates in realtime
- document environment variables

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6871487a2428832c956a015eebf06f22