### PR TITLE
Fix default API URLs to avoid Mixed Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ cd frontend
 npm install
 cp .env.local.example .env.local
 # Configure as variáveis no .env.local (VITE_API_URL e VITE_WS_URL)
+# Use URLs HTTPS para evitar Mixed Content
 npm run dev
 ```
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:3001/api
-VITE_WS_URL=ws://localhost:3001/ws
+VITE_API_URL=https://rtp-api.zapchatbr.com/api
+VITE_WS_URL=wss://rtp-api.zapchatbr.com/ws

--- a/frontend/src/hooks/useRtpSocket.tsx
+++ b/frontend/src/hooks/useRtpSocket.tsx
@@ -20,7 +20,7 @@ export function useRtpSocket() {
 
   useEffect(() => {
     const wsUrl =
-      (import.meta as any).env.VITE_WS_URL || 'ws://localhost:3001/ws'
+      (import.meta as any).env.VITE_WS_URL || 'wss://rtp-api.zapchatbr.com/ws'
     const ws = new WebSocket(wsUrl)
 
     ws.onmessage = (event) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 // Configuração base da API
 const API_BASE_URL =
-  (import.meta as any).env.VITE_API_URL || 'http://rtp-api.zapchatbr.com/api'
+  (import.meta as any).env.VITE_API_URL || 'https://rtp-api.zapchatbr.com/api'
 
 // Criar instância do axios
 export const api = axios.create({


### PR DESCRIPTION
## Summary
- default frontend API endpoints to HTTPS to avoid mixed content
- update websocket URL fallback
- show production URLs in `.env.local.example`
- note to use HTTPS URLs in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68714fd05600832c9fbe6aec98f04cc4