### PR TITLE
Fix HTTP/HTTPS mismatch for API

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:3001/api
-VITE_WS_URL=ws://localhost:3001/ws
+VITE_API_URL=https://rtp-api.zapchatbr.com/api
+VITE_WS_URL=wss://rtp-api.zapchatbr.com/ws

--- a/frontend/src/hooks/useRtpSocket.tsx
+++ b/frontend/src/hooks/useRtpSocket.tsx
@@ -20,7 +20,7 @@ export function useRtpSocket() {
 
   useEffect(() => {
     const wsUrl =
-      (import.meta as any).env.VITE_WS_URL || 'ws://localhost:3001/ws'
+      (import.meta as any).env.VITE_WS_URL || 'wss://rtp-api.zapchatbr.com/ws'
     const ws = new WebSocket(wsUrl)
 
     ws.onmessage = (event) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 // Configuração base da API
 const API_BASE_URL =
-  (import.meta as any).env.VITE_API_URL || 'http://rtp-api.zapchatbr.com/api'
+  (import.meta as any).env.VITE_API_URL || 'https://rtp-api.zapchatbr.com/api'
 
 // Criar instância do axios
 export const api = axios.create({


### PR DESCRIPTION
## Summary
- set HTTPS as default protocol for API calls
- use WSS default for websocket
- update env example to match new defaults

## Testing
- `npm run type-check` *(fails: none)*
- `npm run lint` *(fails: couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68715ab51770832c9c139c82198d7614