### PR TITLE
Fix betting house validation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
     "migrate": "sequelize db:migrate",
-    "seed": "sequelize db:seed:all"
+    "seed": "sequelize db:seed:all",
+    "test": "ts-node tests/bettingHouseController.test.ts"
   },
   "keywords": [
     "express",

--- a/backend/src/controllers/bettingHouseController.ts
+++ b/backend/src/controllers/bettingHouseController.ts
@@ -5,10 +5,18 @@ export const createBettingHouse = async (req: Request, res: Response): Promise<v
   try {
     const { name, apiName, apiUrl, updateInterval, updateIntervalUnit, currency } = req.body;
 
-    if (!name || !apiName || !apiUrl || !updateInterval || !updateIntervalUnit || !currency) {
+    if (!name || !apiName || !apiUrl || updateInterval == null || !updateIntervalUnit || !currency) {
       res.status(400).json({
         error: 'Todos os campos são obrigatórios',
         code: 'MISSING_FIELDS'
+      });
+      return;
+    }
+
+    if (typeof updateInterval !== 'number' || updateInterval <= 0) {
+      res.status(400).json({
+        error: 'Intervalo de atualização deve ser maior que zero',
+        code: 'INVALID_UPDATE_INTERVAL'
       });
       return;
     }
@@ -82,6 +90,23 @@ export const updateBettingHouse = async (req: Request, res: Response): Promise<v
     }
 
     const { name, apiName, apiUrl, updateInterval, updateIntervalUnit, currency } = req.body;
+
+    if (!name || !apiName || !apiUrl || updateInterval == null || !updateIntervalUnit || !currency) {
+      res.status(400).json({
+        error: 'Todos os campos são obrigatórios',
+        code: 'MISSING_FIELDS'
+      });
+      return;
+    }
+
+    if (typeof updateInterval !== 'number' || updateInterval <= 0) {
+      res.status(400).json({
+        error: 'Intervalo de atualização deve ser maior que zero',
+        code: 'INVALID_UPDATE_INTERVAL'
+      });
+      return;
+    }
+
     await house.update({ name, apiName, apiUrl, updateInterval, updateIntervalUnit, currency });
     res.json(house);
   } catch (error) {

--- a/backend/tests/bettingHouseController.test.ts
+++ b/backend/tests/bettingHouseController.test.ts
@@ -1,0 +1,87 @@
+import assert from 'assert';
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+import { createBettingHouse, updateBettingHouse } from '../src/controllers/bettingHouseController';
+import { BettingHouse } from '../src/models/bettingHouse';
+
+class MockResponse {
+  statusCode = 0;
+  body: any;
+  status(code: number) { this.statusCode = code; return this; }
+  json(obj: any) { if (this.statusCode === 0) this.statusCode = 200; this.body = obj; return this; }
+  send() { return this; }
+}
+
+class MockRequest {
+  body: any;
+  params: any;
+  constructor(body: any = {}, params: any = {}) {
+    this.body = body;
+    this.params = params;
+  }
+}
+
+async function run() {
+  // Stub methods
+  (BettingHouse as any).create = async (data: any) => ({ id: 1, ...data });
+  const house = { id: 1, update: async function (data: any) { Object.assign(this, data); } } as any;
+  (BettingHouse as any).findByPk = async (id: number) => (id === 1 ? house : null);
+
+  // create valid
+  const validReq = new MockRequest({
+    name: 'Test',
+    apiName: 'test',
+    apiUrl: 'http://x',
+    updateInterval: 5,
+    updateIntervalUnit: 'seconds',
+    currency: 'USD'
+  });
+  const validRes = new MockResponse();
+  await createBettingHouse(validReq as any, validRes as any);
+  assert.strictEqual(validRes.statusCode, 201, 'create should accept valid interval');
+
+  // create invalid (0)
+  const invalidReq = new MockRequest({
+    name: 'Test',
+    apiName: 'test',
+    apiUrl: 'http://x',
+    updateInterval: 0,
+    updateIntervalUnit: 'seconds',
+    currency: 'USD'
+  });
+  const invalidRes = new MockResponse();
+  await createBettingHouse(invalidReq as any, invalidRes as any);
+  assert.strictEqual(invalidRes.statusCode, 400, 'create should reject zero interval');
+
+  // update invalid (0)
+  const updInvalidReq = new MockRequest({
+    name: 'Test',
+    apiName: 'test',
+    apiUrl: 'http://x',
+    updateInterval: 0,
+    updateIntervalUnit: 'seconds',
+    currency: 'USD'
+  }, { id: '1' });
+  const updInvalidRes = new MockResponse();
+  await updateBettingHouse(updInvalidReq as any, updInvalidRes as any);
+  assert.strictEqual(updInvalidRes.statusCode, 400, 'update should reject zero interval');
+
+  // update valid
+  const updValidReq = new MockRequest({
+    name: 'Test',
+    apiName: 'test',
+    apiUrl: 'http://x',
+    updateInterval: 5,
+    updateIntervalUnit: 'seconds',
+    currency: 'USD'
+  }, { id: '1' });
+  const updValidRes = new MockResponse();
+  await updateBettingHouse(updValidReq as any, updValidRes as any);
+  assert.strictEqual(updValidRes.statusCode, 200, 'update should accept valid interval');
+
+  console.log('All tests passed');
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- validate numeric fields explicitly in bettingHouseController
- enforce updateInterval > 0 on create/update
- add simple unit test covering interval validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871688ea430832c9db9891405eaf416