### PR TITLE
Protect houses/games routes with PrivateRoute

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,17 +28,21 @@ export default function App() {
       <Route
         path="/houses"
         element={
-          <Layout>
-            <HousesPage />
-          </Layout>
+          <PrivateRoute>
+            <Layout>
+              <HousesPage />
+            </Layout>
+          </PrivateRoute>
         }
       />
       <Route
         path="/games"
         element={
-          <Layout>
-            <GamesPage />
-          </Layout>
+          <PrivateRoute>
+            <Layout>
+              <GamesPage />
+            </Layout>
+          </PrivateRoute>
         }
       />
     </Routes>


### PR DESCRIPTION
## Summary
- guard houses and games routes in the frontend router

## Testing
- `npm run type-check` *(fails: none)*
- `npm run lint` *(fails: couldn't find next/core-web-vitals config)*

------
https://chatgpt.com/codex/tasks/task_e_6871688f64c8832c88f4f34ea0098d4d