### PR TITLE
Fix CORS setup for multiple origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ npm run lint         # Linter
    - Confirme as credenciais no .env
 
 2. **Erro de CORS**
-   - Verifique a configuração FRONTEND_URL no backend
+   - Verifique se `FRONTEND_URL` contem todas as origens permitidas (separadas por virgula)
    - Confirme a URL da API no frontend
 
 3. **Erro de autenticação**

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,8 @@
 # Configurações do Servidor
 PORT=3001
 NODE_ENV=development
-FRONTEND_URL=http://localhost:3000
+# Separe multiplas URLs por virgula
+FRONTEND_URL=http://localhost:3000,https://rtp-games.zapchatbr.com
 
 # Configurações do Banco de Dados
 DB_HOST=localhost

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,11 +25,25 @@ db.authenticate().then(() => {
 // Middleware de segurança
 app.use(helmet());
 
-// Configurar CORS
-app.use(cors({
-  origin: process.env.FRONTEND_URL || 'http://localhost:3000',
-  credentials: true
-}));
+// Configurar CORS com suporte a multiplas origens
+const allowedOriginsEnv = process.env.FRONTEND_URL || 'http://localhost:3000';
+const allowedOrigins = allowedOriginsEnv
+  .split(',')
+  .map((url) => url.trim().replace(/\/$/, ''));
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, true);
+      const clean = origin.replace(/\/$/, '');
+      if (allowedOrigins.includes(clean)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Not allowed by CORS'));
+    },
+    credentials: true,
+  }),
+);
 
 // Middleware para parsing JSON
 app.use(express.json({ limit: '10mb' }));


### PR DESCRIPTION
## Summary
- support multiple CORS origins using comma-separated `FRONTEND_URL`
- update env example with note about comma separated origins
- clarify CORS troubleshooting in README

## Testing
- `npm test` in backend
- `npm run lint` in frontend *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68717090e360832cb57893445764338a