### PR TITLE
Fix network fetch stability

### DIFF
--- a/backend/src/utils/rtpFetcher.ts
+++ b/backend/src/utils/rtpFetcher.ts
@@ -6,6 +6,8 @@ export async function fetchRtpData(url: string) {
       accept: 'application/x-protobuf',
       'content-type': 'application/x-protobuf'
     },
+    timeout: Number(process.env.RTP_API_TIMEOUT_MS || 10000),
+    family: 4,
     responseType: 'arraybuffer'
   })
   return res.data

--- a/backend/src/websocket.ts
+++ b/backend/src/websocket.ts
@@ -62,11 +62,13 @@ export class RtpSocket {
     try {
       const res = await axios.post<ArrayBuffer>(house.apiUrl, Buffer.from([8, 2, 16, 2]), {
         responseType: 'arraybuffer',
+        timeout: Number(process.env.RTP_API_TIMEOUT_MS || 10000),
+        family: 4,
         headers: {
           'Content-Type': 'application/x-protobuf',
-          'Origin': house.apiUrl.split('/').slice(0, 3).join('/'),
+          Origin: house.apiUrl.split('/').slice(0, 3).join('/'),
           'User-Agent': 'Mozilla/5.0',
-          'accept': 'application/x-protobuf',
+          accept: 'application/x-protobuf',
         },
       });
       const updates = this.parseProto(res.data, house.id);


### PR DESCRIPTION
## Summary
- add timeout and IPv4 preference when fetching RTP data

## Testing
- `npx jest` *(fails: Need to install jest)*
- `npm run lint` in frontend *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68717b130b88832cb15111392d0ef3f9