### PR TITLE
Implement betting house game fetch

### DIFF
--- a/backend/src/controllers/gameController.ts
+++ b/backend/src/controllers/gameController.ts
@@ -1,5 +1,15 @@
 import { Request, Response } from 'express';
 import { Game } from '../models/game';
+import { BettingHouse } from '../models/bettingHouse';
+import axios from 'axios';
+import { decodeHouseGames, DecodedHouseGame } from '../utils/houseGameDecoder';
+
+interface CacheEntry {
+  timestamp: number;
+  data: DecodedHouseGame[];
+}
+
+const houseCache = new Map<number, CacheEntry>();
 
 export const listGames = async (_req: Request, res: Response): Promise<void> => {
   try {
@@ -7,6 +17,56 @@ export const listGames = async (_req: Request, res: Response): Promise<void> => 
     res.json(games);
   } catch (err) {
     console.error('Erro ao listar jogos:', err);
+    res.status(500).json({ error: 'Erro interno do servidor' });
+  }
+};
+
+export const getHouseGames = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const houseId = parseInt(req.params.id, 10);
+    const house = await BettingHouse.findByPk(houseId);
+    if (!house) {
+      res.status(404).json({ error: 'Casa de aposta não encontrada' });
+      return;
+    }
+
+    const cached = houseCache.get(house.id);
+    const intervalMs =
+      house.updateIntervalUnit === 'minutes'
+        ? house.updateInterval * 60000
+        : house.updateInterval * 1000;
+    const now = Date.now();
+
+    if (!cached || now - cached.timestamp > intervalMs) {
+      try {
+        const response = await axios.post<ArrayBuffer>(
+          house.apiUrl,
+          Buffer.from([8, 1, 16, 2]),
+          {
+            responseType: 'arraybuffer',
+            timeout: Number(process.env.RTP_API_TIMEOUT_MS || 10000),
+            family: 4,
+            headers: {
+              accept: 'application/x-protobuf',
+              'content-type': 'application/x-protobuf',
+              'x-language-iso': 'pt-BR',
+              origin: 'https://cbet.gg',
+              referer: 'https://cbet.gg/pt-BR/casinos/casino/lobby',
+            },
+          },
+        );
+        const games = decodeHouseGames(response.data);
+        houseCache.set(house.id, { timestamp: now, data: games });
+        res.json(games);
+      } catch (err) {
+        console.error('Erro ao consultar API da casa', err);
+        res.status(500).json({ error: 'Falha ao consultar API externa' });
+      }
+    } else {
+      res.json(cached.data);
+    }
+  } catch (err) {
+    console.error('Erro ao obter jogos da casa:', err);
     res.status(500).json({ error: 'Erro interno do servidor' });
   }
 };

--- a/backend/src/proto/house_game.proto
+++ b/backend/src/proto/house_game.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+message ProviderInfo {
+  string name = 2;
+  string slug = 5;
+}
+
+message HouseGame {
+  uint64 id = 1;
+  string name = 2;
+  ProviderInfo provider = 3;
+  string image = 4;
+  uint32 rtpDecimal = 5;
+  uint64 signedInt = 6;
+}
+
+message HouseGameList {
+  repeated HouseGame games = 2;
+}

--- a/backend/src/routes/game.ts
+++ b/backend/src/routes/game.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import { listGames } from '../controllers/gameController';
+import { listGames, getHouseGames } from '../controllers/gameController';
 import { authenticateToken } from '../middleware/auth';
 
 const router = Router();
 
 router.get('/', authenticateToken, listGames);
+router.get('/house/:id', authenticateToken, getHouseGames);
 
 export default router;

--- a/backend/src/utils/houseGameDecoder.ts
+++ b/backend/src/utils/houseGameDecoder.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { loadSync } from 'protobufjs';
+
+const protoInDist = path.join(__dirname, '../proto/house_game.proto');
+const protoInSrc = path.join(__dirname, '../../src/proto/house_game.proto');
+const protoPath = fs.existsSync(protoInDist) ? protoInDist : protoInSrc;
+const root = loadSync(protoPath);
+const GameList = root.lookupType('HouseGameList');
+
+export interface DecodedHouseGame {
+  id: string;
+  name: string;
+  provider: string;
+  image?: string;
+  rtpDecimal: number;
+  signedInt: string;
+}
+
+export function decodeHouseGames(buffer: ArrayBuffer | Uint8Array): DecodedHouseGame[] {
+  const data = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const msg = GameList.decode(data);
+  const obj = GameList.toObject(msg, { longs: String });
+  return (obj.games as any[]).map(g => ({
+    id: g.id as string,
+    name: g.name as string,
+    provider: g.provider?.name as string,
+    image: g.image as string,
+    rtpDecimal: g.rtpDecimal as number,
+    signedInt: g.signedInt as string,
+  }));
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -83,9 +83,11 @@ export const gamesApi = {
   
   getProviders: () =>
     api.get('/games/providers'),
-  
+
   getStats: () =>
     api.get('/games/stats'),
+
+  getHouseGames: (id: number) => api.get(`/games/house/${id}`),
 }
 
 // Funções de RTP

--- a/frontend/src/pages/games/Games.tsx
+++ b/frontend/src/pages/games/Games.tsx
@@ -2,11 +2,12 @@ import React, { useEffect, useState } from 'react'
 import { Card, CardHeader, CardContent } from '@/components/ui/Card'
 import { gamesApi, housesApi } from '@/lib/api'
 import { useRtpSocket } from '@/hooks/useRtpSocket'
-import { Game, BettingHouse } from '@/types'
+import { Game, BettingHouse, HouseGame } from '@/types'
 
 export default function GamesPage() {
   const [games, setGames] = useState<Game[]>([])
   const [houses, setHouses] = useState<BettingHouse[]>([])
+  const [houseGames, setHouseGames] = useState<Record<number, HouseGame[]>>({})
   const updates = useRtpSocket()
 
   useEffect(() => {
@@ -19,6 +20,29 @@ export default function GamesPage() {
       .then((res) => setHouses(res.data))
       .catch(() => {})
   }, [])
+
+  useEffect(() => {
+    const intervals: number[] = []
+    houses.forEach((house) => {
+      const fetchGames = () => {
+        gamesApi
+          .getHouseGames(house.id)
+          .then((res) =>
+            setHouseGames((prev) => ({ ...prev, [house.id]: res.data }))
+          )
+          .catch(() => {})
+      }
+      fetchGames()
+      const ms =
+        house.updateIntervalUnit === 'minutes'
+          ? house.updateInterval * 60000
+          : house.updateInterval * 1000
+      intervals.push(window.setInterval(fetchGames, ms))
+    })
+    return () => {
+      intervals.forEach((id) => clearInterval(id))
+    }
+  }, [houses])
 
   const getRtp = (game: Game, houseId: number) => {
     const up = updates.find((u) => u.gameName === game.name && u.houseId === houseId)
@@ -85,6 +109,50 @@ export default function GamesPage() {
           </div>
         </CardContent>
       </Card>
+      {houses.map((house) => (
+        <Card key={house.id}>
+          <CardHeader>
+            <h3 className="text-lg font-medium text-gray-900">
+              Jogos - {house.name}
+            </h3>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-sm">
+                <thead>
+                  <tr>
+                    <th className="px-4 py-2 text-left">ID</th>
+                    <th className="px-4 py-2 text-left">Nome</th>
+                    <th className="px-4 py-2 text-left">Provedor</th>
+                    <th className="px-4 py-2 text-left">RTP</th>
+                    <th className="px-4 py-2 text-left">Signed</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {(houseGames[house.id] || []).map((g) => (
+                    <tr key={g.id}>
+                      <td className="px-4 py-2">{g.id}</td>
+                      <td className="px-4 py-2 flex items-center space-x-2">
+                        {g.image && (
+                          <img
+                            src={g.image}
+                            alt={g.name}
+                            className="h-10 w-10 object-contain rounded"
+                          />
+                        )}
+                        <span>{g.name}</span>
+                      </td>
+                      <td className="px-4 py-2">{g.provider}</td>
+                      <td className="px-4 py-2">{(g.rtpDecimal / 100).toFixed(2)}%</td>
+                      <td className="px-4 py-2">{g.signedInt}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
     </div>
   )
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -73,6 +73,15 @@ export interface BettingHouse {
   updatedAt: string
 }
 
+export interface HouseGame {
+  id: string
+  name: string
+  provider: string
+  image?: string
+  rtpDecimal: number
+  signedInt: string
+}
+
 // Tipos de RTP
 export interface RtpRecord {
   id: number


### PR DESCRIPTION
## Summary
- add protobuf spec for house games and decoder
- provide API endpoint `/api/games/house/:id` to fetch games from betting house APIs
- expose new method on frontend api
- display fetched house games on Games page
- add type definitions

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717ec49234832ebbce7104e909221e