### PR TITLE
Update games page layout

### DIFF
--- a/frontend/src/components/games/GameCard.tsx
+++ b/frontend/src/components/games/GameCard.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Card } from '@/components/ui/Card'
+import { Game, BettingHouse } from '@/types'
+
+interface GameCardProps {
+  game: Game
+  houses: BettingHouse[]
+  getRtp: (game: Game, houseId: number) => number
+  rtpClass: (value: number) => string
+}
+
+export default function GameCard({ game, houses, getRtp, rtpClass }: GameCardProps) {
+  const image = `https://cgg.bet.br/static/v1/casino/game/0/${game.id}/big.webp`
+  return (
+    <Card className="overflow-hidden">
+      <img
+        src={image}
+        alt={game.name}
+        className="w-full h-24 object-contain border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900"
+      />
+      <div className="p-4 space-y-1">
+        <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+          {game.name}
+        </h4>
+        <p className="text-xs text-gray-500">
+          {game.provider} - {game.category}
+        </p>
+        <p className={`text-sm ${rtpClass(getRtp(game, 0))}`}>
+          RTP {getRtp(game, 0).toFixed(2)}%
+        </p>
+        {houses.map((h) => (
+          <p key={h.id} className={`text-xs ${rtpClass(getRtp(game, h.id))}`}> 
+            {h.name}: {getRtp(game, h.id).toFixed(2)}%
+          </p>
+        ))}
+      </div>
+    </Card>
+  )
+}

--- a/frontend/src/pages/games/Games.tsx
+++ b/frontend/src/pages/games/Games.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { Card, CardHeader, CardContent } from '@/components/ui/Card'
+import GameCard from '@/components/games/GameCard'
 import { gamesApi, housesApi } from '@/lib/api'
 import { useRtpSocket } from '@/hooks/useRtpSocket'
 import { Game, BettingHouse, HouseGame } from '@/types'
@@ -58,54 +59,16 @@ export default function GamesPage() {
           <h3 className="text-lg font-medium text-gray-900">Jogos</h3>
         </CardHeader>
         <CardContent>
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 text-sm">
-              <thead>
-                <tr>
-                  <th className="px-4 py-2 text-left">Jogo</th>
-                  <th className="px-4 py-2 text-left">Provedor</th>
-                  <th className="px-4 py-2 text-left">Categoria</th>
-                  <th className="px-4 py-2 text-left">RTP Min</th>
-                  <th className="px-4 py-2 text-left">RTP Máx</th>
-                  <th className="px-4 py-2 text-left">RTP Atual</th>
-                  {houses.map((h) => (
-                    <th key={h.id} className="px-4 py-2 text-left">
-                      {h.name}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200">
-                {games.map((game) => (
-                  <tr key={game.id}>
-                    <td className="px-4 py-2">
-                      <div className="flex items-center space-x-2">
-                        {game.imageUrl && (
-                          <img
-                            src={game.imageUrl}
-                            alt={game.name}
-                            className="h-10 w-10 sm:h-12 sm:w-12 object-contain rounded"
-                          />
-                        )}
-                        <span>{game.name}</span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-2">{game.provider}</td>
-                    <td className="px-4 py-2">{game.category}</td>
-                    <td className="px-4 py-2">{game.minRtp.toFixed(2)}%</td>
-                    <td className="px-4 py-2">{game.maxRtp.toFixed(2)}%</td>
-                    <td className={"px-4 py-2 " + rtpClass(getRtp(game, 0))}>
-                      {getRtp(game, 0).toFixed(2)}%
-                    </td>
-                    {houses.map((h) => (
-                      <td key={h.id} className={"px-4 py-2 " + rtpClass(getRtp(game, h.id))}>
-                        {getRtp(game, h.id).toFixed(2)}%
-                      </td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-4">
+            {games.map((game) => (
+              <GameCard
+                key={game.id}
+                game={game}
+                houses={houses}
+                getRtp={getRtp}
+                rtpClass={rtpClass}
+              />
+            ))}
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- add `GameCard` component
- display game listing as cards with RTP info and house data

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871899376e4832e925742b8394956dc