### PR TITLE
Ensure houses load before games

### DIFF
--- a/frontend/src/pages/games/Games.tsx
+++ b/frontend/src/pages/games/Games.tsx
@@ -12,15 +12,19 @@ export default function GamesPage() {
   const updates = useRtpSocket()
 
   useEffect(() => {
-    gamesApi
-      .getAll()
-      .then((res) => setGames(res.data))
-      .catch(() => {})
     housesApi
       .getAll()
       .then((res) => setHouses(res.data))
       .catch(() => {})
   }, [])
+
+  useEffect(() => {
+    if (houses.length === 0) return
+    gamesApi
+      .getAll()
+      .then((res) => setGames(res.data))
+      .catch(() => {})
+  }, [houses])
 
   useEffect(() => {
     const intervals: number[] = []


### PR DESCRIPTION
## Summary
- only load games after betting houses are retrieved

## Testing
- `npm test` *(fails: jest not found)*
- `yarn lint` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872e234ac5c832ea2e4342adba92ac2