### PR TITLE
Add admin theme customization page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - 2025-07-16: Implementado serviço WebSocket no backend para envio de RTP em tempo real e adicionada página `Games` no frontend.
 - 2025-07-17: WebSocket agora recarrega periodicamente as casas de aposta para detectar novas entradas sem duplicar intervalos.
 - 2025-07-18: Corrigido carregamento de arquivos .proto no backend; script de build agora copia a pasta `src/proto` para `dist`.
+- 2025-07-19: Adicionada página de administração de tema com salvamento de CSS personalizado no banco e verificação de papel de usuário.
 
 ## Estrutura de Banco de Dados
 

--- a/backend/database/migrations/003_add_role_column.sql
+++ b/backend/database/migrations/003_add_role_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "role" VARCHAR(20) NOT NULL DEFAULT 'user';

--- a/backend/database/migrations/004_create_settings_table.sql
+++ b/backend/database/migrations/004_create_settings_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "settings" (
+  "id" SERIAL PRIMARY KEY,
+  "css" TEXT NOT NULL DEFAULT ''
+);

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -59,21 +59,24 @@ export const register = async (req: Request, res: Response): Promise<void> => {
     const user = await User.create({
       name,
       email,
-      password: hashedPassword
+      password: hashedPassword,
+      role: 'user'
     });
 
     // Gerar token
     const token = generateToken({
       userId: user.id,
       email: user.email,
-      name: user.name
+      name: user.name,
+      role: user.role
     });
 
     const response: AuthResponse = {
       user: {
         id: user.id,
         name: user.name,
-        email: user.email
+        email: user.email,
+        role: user.role
       },
       token
     };
@@ -137,14 +140,16 @@ export const login = async (req: Request, res: Response): Promise<void> => {
     const token = generateToken({
       userId: user.id,
       email: user.email,
-      name: user.name
+      name: user.name,
+      role: user.role
     });
 
     const response: AuthResponse = {
       user: {
         id: user.id,
         name: user.name,
-        email: user.email
+        email: user.email,
+        role: user.role
       },
       token
     };
@@ -173,7 +178,7 @@ export const getProfile = async (req: AuthenticatedRequest, res: Response): Prom
     }
 
     const user = await User.findByPk(req.user.userId, {
-      attributes: ['id', 'name', 'email', 'createdAt', 'updatedAt']
+      attributes: ['id', 'name', 'email', 'role', 'createdAt', 'updatedAt']
     });
 
     if (!user) {
@@ -213,7 +218,8 @@ export const verifyTokenEndpoint = async (req: AuthenticatedRequest, res: Respon
       user: {
         id: req.user.userId,
         name: req.user.name,
-        email: req.user.email
+        email: req.user.email,
+        role: req.user.role
       }
     });
   } catch (error) {

--- a/backend/src/controllers/settingController.ts
+++ b/backend/src/controllers/settingController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express'
+import { Setting } from '../models/setting'
+
+export const getTheme = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const setting = await Setting.findByPk(1)
+    res.json({ css: setting?.css || '' })
+  } catch (error) {
+    console.error('Erro ao obter tema:', error)
+    res.status(500).json({ error: 'Erro interno do servidor' })
+  }
+}
+
+export const updateTheme = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { css } = req.body
+    const [setting] = await Setting.findOrCreate({ where: { id: 1 } })
+    setting.css = css || ''
+    await setting.save()
+    res.json({ success: true })
+  } catch (error) {
+    console.error('Erro ao salvar tema:', error)
+    res.status(500).json({ error: 'Erro interno do servidor' })
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import sequelize from './models';
 import authRoutes from './routes/auth';
 import bettingHouseRoutes from './routes/bettingHouse';
 import gameRoutes from './routes/game';
+import settingRoutes from './routes/setting';
 import initWebSocket from './websocket';
 
 
@@ -53,6 +54,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use('/api/auth', authRoutes);
 app.use('/api/houses', bettingHouseRoutes);
 app.use('/api/games', gameRoutes);
+app.use('/api/settings', settingRoutes);
 
 // Rota de health check
 app.get('/api/health', (req, res) => {

--- a/backend/src/middleware/admin.ts
+++ b/backend/src/middleware/admin.ts
@@ -1,0 +1,14 @@
+import { Response, NextFunction } from 'express'
+import { AuthenticatedRequest } from '../types/auth'
+
+export const requireAdmin = (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): void => {
+  if (!req.user || req.user.role !== 'admin') {
+    res.status(403).json({ error: 'Acesso negado', code: 'FORBIDDEN' })
+    return
+  }
+  next()
+}

--- a/backend/src/models/setting.ts
+++ b/backend/src/models/setting.ts
@@ -1,0 +1,27 @@
+import { DataTypes, Model } from 'sequelize'
+import sequelize from './index'
+
+export class Setting extends Model {
+  public id!: number
+  public css!: string
+}
+
+Setting.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    css: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      defaultValue: '',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'settings',
+    timestamps: false,
+  }
+)

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -6,6 +6,7 @@ interface UserAttributes {
   name: string;
   email: string;
   password: string;
+  role: string;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -18,6 +19,7 @@ export class User extends Model<UserAttributes, UserCreationAttributes>
   public name!: string;
   public email!: string;
   public password!: string;
+  public role!: string;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
 }
@@ -41,6 +43,11 @@ User.init(
     password: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    role: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'user',
     },
     createdAt: DataTypes.DATE,
     updatedAt: DataTypes.DATE,

--- a/backend/src/routes/setting.ts
+++ b/backend/src/routes/setting.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+import { getTheme, updateTheme } from '../controllers/settingController'
+import { authenticateToken } from '../middleware/auth'
+import { requireAdmin } from '../middleware/admin'
+
+const router = Router()
+
+router.get('/theme', authenticateToken, requireAdmin, getTheme)
+router.put('/theme', authenticateToken, requireAdmin, updateTheme)
+
+export default router

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -15,6 +15,7 @@ export interface JwtPayload {
   userId: number;
   email: string;
   name: string;
+  role: string;
 }
 
 export interface AuthenticatedRequest extends Request {
@@ -26,6 +27,7 @@ export interface AuthResponse {
     id: number;
     name: string;
     email: string;
+    role: string;
   };
   token: string;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,8 +6,10 @@ import RegisterPage from './pages/register/Register'
 import DashboardPage from './pages/dashboard/Dashboard'
 import HousesPage from './pages/houses/Houses'
 import GamesPage from './pages/games/Games'
+import ThemeAdminPage from './pages/admin/ThemeAdmin'
 import Layout from './components/layout/Layout'
 import PrivateRoute from './components/routing/PrivateRoute'
+import AdminRoute from './components/routing/AdminRoute'
 
 export default function App() {
   return (
@@ -43,6 +45,16 @@ export default function App() {
               <GamesPage />
             </Layout>
           </PrivateRoute>
+        }
+      />
+      <Route
+        path="/admin/theme"
+        element={
+          <AdminRoute>
+            <Layout>
+              <ThemeAdminPage />
+            </Layout>
+          </AdminRoute>
         }
       />
     </Routes>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -54,6 +54,14 @@ export default function Header() {
                 <BarChart3Icon className="h-4 w-4 inline mr-1" />
                 Estatísticas
               </Link>
+              {user?.role === 'admin' && (
+                <Link
+                  to="/admin/theme"
+                  className="text-gray-600 hover:text-blue-600 px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                >
+                  Tema
+                </Link>
+              )}
             </nav>
           )}
 

--- a/frontend/src/components/routing/AdminRoute.tsx
+++ b/frontend/src/components/routing/AdminRoute.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '@/hooks/useAuth'
+
+interface AdminRouteProps {
+  children: JSX.Element
+}
+
+export default function AdminRoute({ children }: AdminRouteProps) {
+  const { user, loading } = useAuth()
+
+  if (loading) {
+    return <div className="min-h-screen flex items-center justify-center">Carregando...</div>
+  }
+
+  if (!user || user.role !== 'admin') {
+    return <Navigate to="/" replace />
+  }
+
+  return children
+}

--- a/frontend/src/hooks/useCustomCss.tsx
+++ b/frontend/src/hooks/useCustomCss.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { settingsApi } from '@/lib/api'
+
+interface CustomCssContextProps {
+  css: string
+  updateCss: (css: string) => Promise<void>
+}
+
+const CustomCssContext = createContext<CustomCssContextProps | undefined>(undefined)
+
+function applyCss(css: string) {
+  let tag = document.getElementById('custom-css') as HTMLStyleElement | null
+  if (!tag) {
+    tag = document.createElement('style')
+    tag.id = 'custom-css'
+    document.head.appendChild(tag)
+  }
+  tag.innerHTML = css
+}
+
+export function CustomCssProvider({ children }: { children: ReactNode }) {
+  const [css, setCss] = useState('')
+
+  useEffect(() => {
+    settingsApi.getTheme()
+      .then(res => {
+        setCss(res.data.css || '')
+        applyCss(res.data.css || '')
+      })
+      .catch(() => {})
+  }, [])
+
+  const updateCss = async (newCss: string) => {
+    await settingsApi.updateTheme({ css: newCss })
+    setCss(newCss)
+    applyCss(newCss)
+  }
+
+  return (
+    <CustomCssContext.Provider value={{ css, updateCss }}>
+      {children}
+    </CustomCssContext.Provider>
+  )
+}
+
+export function useCustomCss() {
+  const ctx = useContext(CustomCssContext)
+  if (!ctx) throw new Error('useCustomCss must be used within CustomCssProvider')
+  return ctx
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -147,6 +147,12 @@ export const housesApi = {
   remove: (id: number) => api.delete(`/houses/${id}`),
 }
 
+// Funções de configurações
+export const settingsApi = {
+  getTheme: () => api.get('/settings/theme'),
+  updateTheme: (data: { css: string }) => api.put('/settings/theme', data),
+}
+
 // Função para verificar se a API está online
 export const checkApiHealth = async (): Promise<boolean> => {
   try {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,15 +5,18 @@ import App from './App'
 import './globals.css'
 import { AuthProvider } from './hooks/useAuth'
 import { ThemeProvider } from './hooks/useTheme'
+import { CustomCssProvider } from './hooks/useCustomCss'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <ThemeProvider>
-      <AuthProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </AuthProvider>
+      <CustomCssProvider>
+        <AuthProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </AuthProvider>
+      </CustomCssProvider>
     </ThemeProvider>
   </React.StrictMode>
 )

--- a/frontend/src/pages/admin/ThemeAdmin.tsx
+++ b/frontend/src/pages/admin/ThemeAdmin.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react'
+import { Card, CardHeader, CardContent } from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import { settingsApi } from '@/lib/api'
+import { useCustomCss } from '@/hooks/useCustomCss'
+
+export default function ThemeAdminPage() {
+  const { updateCss } = useCustomCss()
+  const [css, setCss] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    settingsApi.getTheme()
+      .then(res => setCss(res.data.css || ''))
+      .catch(() => setError('Erro ao carregar tema'))
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    try {
+      await updateCss(css)
+    } catch {
+      setError('Erro ao salvar tema')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-medium text-gray-900">Personalizar Tema</h3>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">{error}</div>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <textarea
+              value={css}
+              onChange={(e) => setCss(e.target.value)}
+              className="w-full h-64 p-2 border border-gray-300 rounded-md font-mono text-sm dark:bg-gray-800 dark:text-gray-100"
+            />
+            <Button type="submit" loading={loading}>Salvar</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,6 +3,7 @@ export interface User {
   id: number
   name: string
   email: string
+  role: string
   createdAt: string
   updatedAt: string
 }
@@ -156,6 +157,10 @@ export interface TableColumn<T> {
   label: string
   sortable?: boolean
   render?: (item: T) => React.ReactNode
+}
+
+export interface ThemeData {
+  css: string
 }
 
 // Tipos de contexto


### PR DESCRIPTION
## Summary
- allow admins to customize CSS theme from a new page
- store theme CSS in database and expose new API endpoints
- support user roles with new `role` column
- update header navigation and add admin route
- add migrations and models for settings

## Testing
- `npm test --silent` in `backend`
- `yarn lint` *(fails: couldn't find `next/core-web-vitals`)*

------
https://chatgpt.com/codex/tasks/task_e_6873ac31a5ac832c8a15998ab78edb99