### PR TITLE
Add game filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - 2025-07-16: Implementado serviço WebSocket no backend para envio de RTP em tempo real e adicionada página `Games` no frontend.
 - 2025-07-17: WebSocket agora recarrega periodicamente as casas de aposta para detectar novas entradas sem duplicar intervalos.
 - 2025-07-18: Corrigido carregamento de arquivos .proto no backend; script de build agora copia a pasta `src/proto` para `dist`.
+- 2025-07-19: Adicionados filtros de jogos por nome, provedor e RTP positivo/negativo na página `Games`.
 
 ## Estrutura de Banco de Dados
 


### PR DESCRIPTION
## Summary
- add search, provider and RTP filters on Games page
- document the new filters in AGENTS

## Testing
- `npm test` in backend
- `npm run type-check` in frontend
- `npm run lint` *(fails: couldn't find `next/core-web-vitals` config)*

------
https://chatgpt.com/codex/tasks/task_e_6873b3d98130832c9391c48590fd9360