### PR TITLE
Add user profile with password change

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ npm run lint         # Linter
 - `POST /api/auth/login` - Login
 - `GET /api/auth/profile` - Perfil do usuário
 - `GET /api/auth/verify` - Verificar token
+- `POST /api/auth/change-password` - Alterar senha
 
 ### Jogos
 - `GET /api/games` - Listar jogos

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { register, login, getProfile, verifyTokenEndpoint } from '../controllers/authController';
+import { register, login, getProfile, verifyTokenEndpoint, changePassword } from '../controllers/authController';
 import { authenticateToken } from '../middleware/auth';
 
 const router = Router();
@@ -11,6 +11,7 @@ router.post('/login', login);
 // Rotas protegidas
 router.get('/profile', authenticateToken, getProfile);
 router.get('/verify', authenticateToken, verifyTokenEndpoint);
+router.post('/change-password', authenticateToken, changePassword);
 
 export default router;
 

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -11,6 +11,11 @@ export interface LoginRequest {
   password: string;
 }
 
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+}
+
 export interface JwtPayload {
   userId: number;
   email: string;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import RegisterPage from './pages/register/Register'
 import DashboardPage from './pages/dashboard/Dashboard'
 import HousesPage from './pages/houses/Houses'
 import GamesPage from './pages/games/Games'
+import ProfilePage from './pages/profile/Profile'
 import Layout from './components/layout/Layout'
 import PrivateRoute from './components/routing/PrivateRoute'
 
@@ -41,6 +42,16 @@ export default function App() {
           <PrivateRoute>
             <Layout>
               <GamesPage />
+            </Layout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/profile"
+        element={
+          <PrivateRoute>
+            <Layout>
+              <ProfilePage />
             </Layout>
           </PrivateRoute>
         }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -62,12 +62,12 @@ export default function Header() {
             <ThemeToggle />
             {isAuthenticated ? (
               <div className="flex items-center space-x-3">
-                <div className="flex items-center space-x-2">
+                <Link to="/profile" className="flex items-center space-x-2">
                   <UserIcon className="h-5 w-5 text-gray-500" />
                   <span className="text-sm font-medium text-gray-700">
                     {user?.name}
                   </span>
-                </div>
+                </Link>
                 <Button
                   variant="ghost"
                   size="sm"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -58,9 +58,12 @@ export const authApi = {
   
   getProfile: () =>
     api.get('/auth/profile'),
-  
+
   verifyToken: () =>
     api.get('/auth/verify'),
+
+  changePassword: (data: { currentPassword: string; newPassword: string }) =>
+    api.post('/auth/change-password', data),
 }
 
 // Funções de jogos

--- a/frontend/src/pages/profile/Profile.tsx
+++ b/frontend/src/pages/profile/Profile.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useAuth } from '@/hooks/useAuth'
+import { authApi } from '@/lib/api'
+import { Card, CardHeader, CardContent } from '@/components/ui/Card'
+import Input from '@/components/ui/Input'
+import Button from '@/components/ui/Button'
+
+const schema = z
+  .object({
+    currentPassword: z.string().min(6, 'Senha deve ter pelo menos 6 caracteres'),
+    newPassword: z.string().min(6, 'Senha deve ter pelo menos 6 caracteres'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'Senhas não coincidem',
+    path: ['confirmPassword'],
+  })
+
+interface FormData {
+  currentPassword: string
+  newPassword: string
+  confirmPassword: string
+}
+
+export default function ProfilePage() {
+  const { user } = useAuth()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  })
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      setLoading(true)
+      setError('')
+      setSuccess('')
+      await authApi.changePassword({
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+      })
+      setSuccess('Senha alterada com sucesso')
+      reset()
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error &&
+        'response' in err &&
+        typeof (err as any).response?.data?.error === 'string'
+          ? String((err as any).response.data.error)
+          : 'Erro ao alterar senha'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-medium text-gray-900">Seus Dados</h3>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>
+            <strong>Nome:</strong> {user?.name}
+          </p>
+          <p>
+            <strong>Email:</strong> {user?.email}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-medium text-gray-900">Alterar Senha</h3>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="mb-4 bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-md">
+              {success}
+            </div>
+          )}
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <Input
+              label="Senha atual"
+              type="password"
+              error={errors.currentPassword?.message}
+              {...register('currentPassword')}
+            />
+            <Input
+              label="Nova senha"
+              type="password"
+              error={errors.newPassword?.message}
+              {...register('newPassword')}
+            />
+            <Input
+              label="Confirmar nova senha"
+              type="password"
+              error={errors.confirmPassword?.message}
+              {...register('confirmPassword')}
+            />
+            <Button type="submit" loading={loading}>
+              Alterar Senha
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add backend change-password API endpoint
- expose changePassword via authApi
- create profile page with password update form
- wire new profile page in routes and header link
- document endpoint in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b9f5b90c832e8a1f2e0ff538304d