### PR TITLE
Handle negative RTP sign

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -60,6 +60,22 @@ export function getRtpBgColor(rtp: number): string {
 }
 
 /**
+ * Ajusta o sinal do valor RTP recebido via rtpDecimal de acordo com signedInt
+ */
+export function applySignedInt(rtpDecimal: number, signedInt?: string | number): number {
+  if (signedInt === undefined) return rtpDecimal
+  try {
+    const val = BigInt(signedInt)
+    const maxPositive = BigInt('9223372036854775807')
+    const max = BigInt('18446744073709551616')
+    const signed = val > maxPositive ? val - max : val
+    return signed < 0n ? -rtpDecimal : rtpDecimal
+  } catch {
+    return rtpDecimal
+  }
+}
+
+/**
  * Debounce function para otimizar pesquisas
  */
 export function debounce<T extends (...args: unknown[]) => unknown>(

--- a/frontend/src/pages/games/Games.tsx
+++ b/frontend/src/pages/games/Games.tsx
@@ -4,6 +4,7 @@ import GameCard from '@/components/games/GameCard'
 import { gamesApi, housesApi } from '@/lib/api'
 import { useRtpSocket } from '@/hooks/useRtpSocket'
 import { Game, BettingHouse } from '@/types'
+import { applySignedInt } from '@/lib/utils'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
 
@@ -78,7 +79,8 @@ export default function GamesPage() {
   // Retorna o RTP do jogo mais atualizado
   const getRtp = (game: Game, houseId: number): number => {
     const up = updates.find((u) => u.gameName === game.name && u.houseId === houseId)
-    const rawRtp = up?.rtp ?? game.rtpDecimal ?? 0
+    const base = applySignedInt(game.rtpDecimal ?? 0, game.signedInt)
+    const rawRtp = up?.rtp ?? base
     return rawRtp / 100
   }
 


### PR DESCRIPTION
## Summary
- interpret signedInt field to assign the correct sign to RTP values
- use new applySignedInt helper when displaying games

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873be1ecb00832e8aff616803dfaf3f