### PR TITLE
Add RTP period support

### DIFF
--- a/frontend/src/components/games/GameCard.tsx
+++ b/frontend/src/components/games/GameCard.tsx
@@ -7,7 +7,7 @@ import { ArrowUpIcon, ArrowDownIcon } from 'lucide-react'
 interface GameCardProps {
   game: Game
   house: BettingHouse
-  getRtp: (game: Game, houseId: number) => number
+  getRtp: (game: Game, houseId: number, period: 'daily' | 'weekly' | 'monthly') => number
   rtpClass: (value: number) => string
   className?: string
 }
@@ -33,9 +33,9 @@ export default function GameCard({ game, house, getRtp, rtpClass, className }: G
         <p className="text-xs text-gray-500">
           {game.provider} 
         </p>
-        <p className={`text-sm ${rtpClass(getRtp(game, house.id))}`}>
-          RTP {getRtp(game, house.id).toFixed(2)}%
-        </p>
+        <p className={`text-sm ${rtpClass(getRtp(game, house.id, 'daily'))}`}>Dia {getRtp(game, house.id, 'daily').toFixed(2)}%</p>
+        <p className={`text-sm ${rtpClass(getRtp(game, house.id, 'weekly'))}`}>Semana {getRtp(game, house.id, 'weekly').toFixed(2)}%</p>
+        <p className={`text-sm ${rtpClass(getRtp(game, house.id, 'monthly'))}`}>Mês {getRtp(game, house.id, 'monthly').toFixed(2)}%</p>
         <div className="flex items-center text-xs">
           {positive ? (
             <ArrowUpIcon className="h-3 w-3 text-green-600 mr-1" />

--- a/frontend/src/hooks/useRtpSocket.tsx
+++ b/frontend/src/hooks/useRtpSocket.tsx
@@ -11,7 +11,9 @@ export interface RtpUpdate {
   houseId: number
   gameName: string
   provider: string
-  rtp: number
+  rtpDaily?: number
+  rtpWeekly?: number
+  rtpMonthly?: number
   imageUrl?: string
 }
 
@@ -29,7 +31,9 @@ export function useRtpSocket() {
         if (payload.type === 'rtp') {
           const adjusted = (payload.data as RtpUpdate[]).map((u) => ({
             ...u,
-            rtp: adjustRtp(u.rtp),
+            rtpDaily: u.rtpDaily !== undefined ? adjustRtp(u.rtpDaily) : undefined,
+            rtpWeekly: u.rtpWeekly !== undefined ? adjustRtp(u.rtpWeekly) : undefined,
+            rtpMonthly: u.rtpMonthly !== undefined ? adjustRtp(u.rtpMonthly) : undefined,
           }))
           setUpdates((prev) => {
             const map = new Map(prev.map((u) => [`${u.houseId}:${u.gameName}`, u]))

--- a/frontend/src/pages/games/Games.tsx
+++ b/frontend/src/pages/games/Games.tsx
@@ -77,10 +77,18 @@ export default function GamesPage() {
 
 
   // Retorna o RTP do jogo mais atualizado
-  const getRtp = (game: Game, houseId: number): number => {
+  const getRtp = (
+    game: Game,
+    houseId: number,
+    period: 'daily' | 'weekly' | 'monthly'
+  ): number => {
     const up = updates.find((u) => u.gameName === game.name && u.houseId === houseId)
     const base = applySignedInt(game.rtpDecimal ?? 0, game.signedInt)
-    const rawRtp = up?.rtp ?? base
+    let raw: number | undefined
+    if (period === 'daily') raw = up?.rtpDaily
+    else if (period === 'weekly') raw = up?.rtpWeekly
+    else raw = up?.rtpMonthly
+    const rawRtp = raw ?? base
     return rawRtp / 100
   }
 
@@ -164,7 +172,7 @@ export default function GamesPage() {
 
         if (rtpFilter !== 'all') {
           filteredGames = filteredGames.filter((g) => {
-            const rtp = getRtp(g, house.id)
+            const rtp = getRtp(g, house.id, 'daily')
             return rtpFilter === 'positive' ? rtp >= 0 : rtp < 0
           })
         }


### PR DESCRIPTION
## Summary
- extend RTP websocket update with daily, weekly and monthly values
- handle new RTP fields on the frontend socket hook
- display RTP per period on game cards
- filter games using daily RTP values

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6873c63f5124832e9c5dbc056bc9c556