### PR TITLE
Add toast notifications to frontend

### DIFF
--- a/frontend/src/components/games/GameCard.tsx
+++ b/frontend/src/components/games/GameCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Card } from '@/components/ui/Card'
 import { cn, convertSignedInt } from '@/lib/utils'
+import { useToast } from '@/hooks/useToast'
 import { Game, BettingHouse } from '@/types'
 import { ArrowUpIcon, ArrowDownIcon } from 'lucide-react'
 
@@ -15,11 +16,15 @@ interface GameCardProps {
 export default function GameCard({ game, house, getRtp, rtpClass, className }: GameCardProps) {
   const signed = convertSignedInt(game.signedInt)
   const positive = signed >= 0
-  return (
-    <Card onClick={() => {
+  const { show } = useToast()
+  const handleClick = () => {
     navigator.clipboard.writeText(game.name)
-    }}
-    className={cn('overflow-hidden', className)}
+    show({ type: 'info', title: `${game.name} copiado` })
+  }
+  return (
+    <Card
+      onClick={handleClick}
+      className={cn('overflow-hidden cursor-pointer', className)}
     >
       <img
         src={`data:image/webp;base64,${game.imageUrl}`}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { useToast } from '@/hooks/useToast'
+import { XIcon, CheckCircle2Icon, AlertTriangleIcon, InfoIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export default function ToastContainer() {
+  const { toasts, remove } = useToast()
+
+  const icons = {
+    success: <CheckCircle2Icon className="h-5 w-5 text-green-600" />,
+    error: <XIcon className="h-5 w-5 text-red-600" />,
+    warning: <AlertTriangleIcon className="h-5 w-5 text-yellow-600" />,
+    info: <InfoIcon className="h-5 w-5 text-blue-600" />,
+  }
+
+  return (
+    <div className="fixed top-4 right-4 space-y-2 z-50">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className={cn(
+            'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow rounded-md p-3 flex items-start space-x-2'
+          )}
+        >
+          {icons[t.type]}
+          <div className="flex-1">
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{t.title}</p>
+            {t.message && <p className="text-sm text-gray-500">{t.message}</p>}
+          </div>
+          <button
+            onClick={() => remove(t.id)}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <XIcon className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useToast.tsx
+++ b/frontend/src/hooks/useToast.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react'
+import { Notification } from '@/types'
+
+interface ToastContextType {
+  toasts: Notification[]
+  show: (toast: Omit<Notification, 'id'>) => void
+  remove: (id: string) => void
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined)
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Notification[]>([])
+
+  const show = (toast: Omit<Notification, 'id'>) => {
+    const id = crypto.randomUUID()
+    const newToast = { ...toast, id }
+    setToasts((prev) => [...prev, newToast])
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id))
+    }, toast.duration ?? 3000)
+  }
+
+  const remove = (id: string) =>
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+
+  return (
+    <ToastContext.Provider value={{ toasts, show, remove }}>
+      {children}
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) throw new Error('useToast must be used within a ToastProvider')
+  return context
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,15 +5,20 @@ import App from './App'
 import './globals.css'
 import { AuthProvider } from './hooks/useAuth'
 import { ThemeProvider } from './hooks/useTheme'
+import { ToastProvider } from './hooks/useToast'
+import ToastContainer from './components/ui/Toast'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <ThemeProvider>
-      <AuthProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </AuthProvider>
+      <ToastProvider>
+        <AuthProvider>
+          <BrowserRouter>
+            <App />
+            <ToastContainer />
+          </BrowserRouter>
+        </AuthProvider>
+      </ToastProvider>
     </ThemeProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- implement `useToast` context and provider
- create `ToastContainer` component for displaying notifications
- show toast after copying game name to clipboard
- wrap app in `ToastProvider` and render `ToastContainer`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: cannot find type definitions)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c8bd6250832ea958d0d0fec2a8ec