### PR TITLE
Refactor RTP handling via WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ npm run lint         # Linter
 - `GET /api/games/categories` - Categorias
 - `GET /api/games/providers` - Provedores
 - `GET /api/games/stats` - Estatísticas
+- `GET /api/games/house/:id` - Jogos disponíveis na casa (RTP via WebSocket)
 
 ### RTP
 - `POST /api/rtp` - Adicionar registro

--- a/backend/src/controllers/gameController.ts
+++ b/backend/src/controllers/gameController.ts
@@ -1,16 +1,7 @@
 import { Request, Response } from 'express';
 import { Game } from '../models/game';
 import { BettingHouse } from '../models/bettingHouse';
-import axios from 'axios';
-import https from 'https';
-import { decodeHouseGames, DecodedHouseGame } from '../utils/houseGameDecoder';
-
-interface CacheEntry {
-  timestamp: number;
-  data: DecodedHouseGame[];
-}
-
-const houseCache = new Map<number, CacheEntry>();
+import { fetchHouseGames } from '../utils/houseGameFetcher';
 
 export const listGames = async (_req: Request, res: Response): Promise<void> => {
   try {
@@ -31,62 +22,8 @@ export const getHouseGames = async (req: Request, res: Response): Promise<void> 
       return;
     }
 
-    const cached = houseCache.get(house.id);
-    const intervalMs =
-      house.updateIntervalUnit === 'minutes'
-        ? house.updateInterval * 60000
-        : house.updateInterval * 1000;
-    const now = Date.now();
-
-    const verifySsl = (process.env.VERIFY_SSL || 'true').toLowerCase() !== 'false';
-    const httpsAgent = new https.Agent({ rejectUnauthorized: verifySsl });
-
-
-    if (!cached || now - cached.timestamp > intervalMs) {
-      try {
-        const response = await axios.post<ArrayBuffer>(
-          house.apiUrl,
-          Buffer.from([8, 1, 16, 2]),
-          {
-            responseType: 'arraybuffer',
-            timeout: Number(process.env.RTP_API_TIMEOUT_MS || 10000),
-            family: 4,
-            httpsAgent,
-            headers: {
-              accept: 'application/x-protobuf',
-              'content-type': 'application/x-protobuf',
-              'x-language-iso': 'pt-BR'
-            },
-          },
-        );
-        const games = decodeHouseGames(response.data);
-        const gamesWithImages = await Promise.all(
-          games.map(async g => {
-            const domain = house.name.toLowerCase().includes('cbet')
-              ? 'cbet.gg'
-              : 'cgg.bet.br';
-            const url = `https://${domain}/static/v1/casino/game/0/${g.id}/big.webp`;
-            try {
-              const img = await axios.get<ArrayBuffer>(url, {
-                responseType: 'arraybuffer',
-                httpsAgent,
-              });
-              const b64 = Buffer.from(img.data).toString('base64');
-              return { ...g, imageUrl: b64 } as DecodedHouseGame;
-            } catch {
-              return { ...g } as DecodedHouseGame;
-            }
-          })
-        );
-        houseCache.set(house.id, { timestamp: now, data: gamesWithImages });
-        res.json(gamesWithImages);
-      } catch (err) {
-        console.error('Erro ao consultar API da casa', err);
-        res.status(500).json({ error: 'Falha ao consultar API externa' });
-      }
-    } else {
-      res.json(cached.data);
-    }
+    const games = await fetchHouseGames(house);
+    res.json(games);
   } catch (err) {
     console.error('Erro ao obter jogos da casa:', err);
     res.status(500).json({ error: 'Erro interno do servidor' });

--- a/backend/src/utils/houseGameFetcher.ts
+++ b/backend/src/utils/houseGameFetcher.ts
@@ -1,0 +1,64 @@
+import axios from 'axios';
+import https from 'https';
+import { BettingHouse } from '../models/bettingHouse';
+import { decodeHouseGames, DecodedHouseGame } from './houseGameDecoder';
+
+interface CacheEntry {
+  timestamp: number;
+  data: DecodedHouseGame[];
+}
+
+const houseCache = new Map<number, CacheEntry>();
+
+export async function fetchHouseGames(house: BettingHouse): Promise<DecodedHouseGame[]> {
+  const cached = houseCache.get(house.id);
+  const intervalMs =
+    house.updateIntervalUnit === 'minutes'
+      ? house.updateInterval * 60000
+      : house.updateInterval * 1000;
+  const now = Date.now();
+
+  const verifySsl = (process.env.VERIFY_SSL || 'true').toLowerCase() !== 'false';
+  const httpsAgent = new https.Agent({ rejectUnauthorized: verifySsl });
+
+  if (cached && now - cached.timestamp <= intervalMs) {
+    return cached.data;
+  }
+
+  const response = await axios.post<ArrayBuffer>(
+    house.apiUrl,
+    Buffer.from([8, 1, 16, 2]),
+    {
+      responseType: 'arraybuffer',
+      timeout: Number(process.env.RTP_API_TIMEOUT_MS || 10000),
+      family: 4,
+      httpsAgent,
+      headers: {
+        accept: 'application/x-protobuf',
+        'content-type': 'application/x-protobuf',
+        'x-language-iso': 'pt-BR',
+      },
+    },
+  );
+
+  const games = decodeHouseGames(response.data);
+  const gamesWithImages = await Promise.all(
+    games.map(async g => {
+      const domain = house.name.toLowerCase().includes('cbet') ? 'cbet.gg' : 'cgg.bet.br';
+      const url = `https://${domain}/static/v1/casino/game/0/${g.id}/big.webp`;
+      try {
+        const img = await axios.get<ArrayBuffer>(url, {
+          responseType: 'arraybuffer',
+          httpsAgent,
+        });
+        const b64 = Buffer.from(img.data).toString('base64');
+        return { ...g, imageUrl: b64 } as DecodedHouseGame;
+      } catch {
+        return { ...g } as DecodedHouseGame;
+      }
+    })
+  );
+
+  houseCache.set(house.id, { timestamp: now, data: gamesWithImages });
+  return gamesWithImages;
+}

--- a/frontend/src/pages/games/Games.tsx
+++ b/frontend/src/pages/games/Games.tsx
@@ -4,7 +4,6 @@ import GameCard from '@/components/games/GameCard'
 import { gamesApi, housesApi } from '@/lib/api'
 import { useRtpSocket } from '@/hooks/useRtpSocket'
 import { Game, BettingHouse } from '@/types'
-import { applySignedInt } from '@/lib/utils'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
 
@@ -83,13 +82,11 @@ export default function GamesPage() {
     period: 'daily' | 'weekly' | 'monthly'
   ): number => {
     const up = updates.find((u) => u.gameName === game.name && u.houseId === houseId)
-    const base = applySignedInt(game.rtpDecimal ?? 0, game.signedInt)
     let raw: number | undefined
     if (period === 'daily') raw = up?.rtpDaily
     else if (period === 'weekly') raw = up?.rtpWeekly
     else raw = up?.rtpMonthly
-    const rawRtp = raw ?? base
-    return rawRtp / 100
+    return (raw ?? 0) / 100
   }
 
   const toggleExpanded = (houseId: number) => {


### PR DESCRIPTION
## Summary
- extract house game fetching to a reusable helper
- simplify getHouseGames controller to use helper
- rely solely on WebSocket for RTP on Games page
- document games/house API endpoint

## Testing
- `npm install` *(fails: couldn't reach registry)*
- `npm test` *(fails: jest not found)*
- `yarn lint` *(fails: couldn't find node_modules state)*

------
https://chatgpt.com/codex/tasks/task_e_6873dcbd95a8832e911db3dae043e5e1