### PR TITLE
Fix RTP fetch to use daily period only

### DIFF
--- a/frontend/src/components/games/GameCard.tsx
+++ b/frontend/src/components/games/GameCard.tsx
@@ -8,7 +8,7 @@ import { ArrowUpIcon, ArrowDownIcon } from 'lucide-react'
 interface GameCardProps {
   game: Game
   house: BettingHouse
-  getRtp: (game: Game, houseId: number, period: 'daily' | 'weekly' | 'monthly') => number
+  getRtp: (game: Game, houseId: number) => number
   rtpClass: (value: number) => string
   className?: string
 }
@@ -38,9 +38,9 @@ export default function GameCard({ game, house, getRtp, rtpClass, className }: G
         <p className="text-xs text-gray-500">
           {game.provider} 
         </p>
-        <p className={`text-sm ${rtpClass(getRtp(game, house.id, 'daily'))}`}>Dia {getRtp(game, house.id, 'daily').toFixed(2)}%</p>
-        <p className={`text-sm ${rtpClass(getRtp(game, house.id, 'weekly'))}`}>Semana {getRtp(game, house.id, 'weekly').toFixed(2)}%</p>
-        <p className={`text-sm ${rtpClass(getRtp(game, house.id, 'monthly'))}`}>Mês {getRtp(game, house.id, 'monthly').toFixed(2)}%</p>
+        <p className={`text-sm ${rtpClass(getRtp(game, house.id))}`}>
+          RTP {getRtp(game, house.id).toFixed(2)}%
+        </p>
         <div className="flex items-center text-xs">
           {positive ? (
             <ArrowUpIcon className="h-3 w-3 text-green-600 mr-1" />

--- a/frontend/src/hooks/useRtpSocket.tsx
+++ b/frontend/src/hooks/useRtpSocket.tsx
@@ -11,9 +11,7 @@ export interface RtpUpdate {
   houseId: number
   gameName: string
   provider: string
-  rtpDaily?: number
-  rtpWeekly?: number
-  rtpMonthly?: number
+  rtp: number
   imageUrl?: string
 }
 
@@ -31,9 +29,7 @@ export function useRtpSocket() {
         if (payload.type === 'rtp') {
           const adjusted = (payload.data as RtpUpdate[]).map((u) => ({
             ...u,
-            rtpDaily: u.rtpDaily !== undefined ? adjustRtp(u.rtpDaily) : undefined,
-            rtpWeekly: u.rtpWeekly !== undefined ? adjustRtp(u.rtpWeekly) : undefined,
-            rtpMonthly: u.rtpMonthly !== undefined ? adjustRtp(u.rtpMonthly) : undefined,
+            rtp: adjustRtp(u.rtp),
           }))
           setUpdates((prev) => {
             const map = new Map(prev.map((u) => [`${u.houseId}:${u.gameName}`, u]))

--- a/frontend/src/pages/games/Games.tsx
+++ b/frontend/src/pages/games/Games.tsx
@@ -4,6 +4,7 @@ import GameCard from '@/components/games/GameCard'
 import { gamesApi, housesApi } from '@/lib/api'
 import { useRtpSocket } from '@/hooks/useRtpSocket'
 import { Game, BettingHouse } from '@/types'
+import { applySignedInt } from '@/lib/utils'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
 
@@ -76,17 +77,11 @@ export default function GamesPage() {
 
 
   // Retorna o RTP do jogo mais atualizado
-  const getRtp = (
-    game: Game,
-    houseId: number,
-    period: 'daily' | 'weekly' | 'monthly'
-  ): number => {
+  const getRtp = (game: Game, houseId: number): number => {
     const up = updates.find((u) => u.gameName === game.name && u.houseId === houseId)
-    let raw: number | undefined
-    if (period === 'daily') raw = up?.rtpDaily
-    else if (period === 'weekly') raw = up?.rtpWeekly
-    else raw = up?.rtpMonthly
-    return (raw ?? 0) / 100
+    const base = applySignedInt(game.rtpDecimal ?? 0, game.signedInt)
+    const rawRtp = up?.rtp ?? base
+    return rawRtp / 100
   }
 
   const toggleExpanded = (houseId: number) => {
@@ -169,7 +164,7 @@ export default function GamesPage() {
 
         if (rtpFilter !== 'all') {
           filteredGames = filteredGames.filter((g) => {
-            const rtp = getRtp(g, house.id, 'daily')
+            const rtp = getRtp(g, house.id)
             return rtpFilter === 'positive' ? rtp >= 0 : rtp < 0
           })
         }


### PR DESCRIPTION
## Summary
- simplify WebSocket RTP fetching to query only daily values
- adapt socket hook and components for single RTP value

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in frontend *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6873ecd08fdc832e9e8bec2905ac31da