### PR TITLE
Increase API timeout

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,6 @@ JWT_EXPIRES_IN=7d
 # Configurações de Segurança
 BCRYPT_ROUNDS=12
 
+# Tempo máximo de espera (ms) ao consultar APIs de jogos
+RTP_API_TIMEOUT_MS=20000
+

--- a/backend/src/utils/houseGameFetcher.ts
+++ b/backend/src/utils/houseGameFetcher.ts
@@ -30,7 +30,7 @@ export async function fetchHouseGames(house: BettingHouse): Promise<DecodedHouse
     Buffer.from([8, 1, 16, 2]),
     {
       responseType: 'arraybuffer',
-      timeout: Number(process.env.RTP_API_TIMEOUT_MS || 10000),
+      timeout: Number(process.env.RTP_API_TIMEOUT_MS || 20000),
       family: 4,
       httpsAgent,
       headers: {

--- a/backend/src/utils/rtpFetcher.ts
+++ b/backend/src/utils/rtpFetcher.ts
@@ -6,7 +6,7 @@ export async function fetchRtpData(url: string) {
       accept: 'application/x-protobuf',
       'content-type': 'application/x-protobuf'
     },
-    timeout: Number(process.env.RTP_API_TIMEOUT_MS || 10000),
+    timeout: Number(process.env.RTP_API_TIMEOUT_MS || 20000),
     family: 4,
     responseType: 'arraybuffer'
   })

--- a/backend/src/websocket.ts
+++ b/backend/src/websocket.ts
@@ -60,7 +60,7 @@ export class RtpSocket {
 
   private async fetchAndBroadcast(house: BettingHouse) {
     try {
-      const baseTimeout = Number(process.env.RTP_API_TIMEOUT_MS || 10000);
+      const baseTimeout = Number(process.env.RTP_API_TIMEOUT_MS || 20000);
       const common: AxiosRequestConfig = {
         responseType: 'arraybuffer',
         family: 4 as 4,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7,7 +7,7 @@ const API_BASE_URL =
 // Criar instância do axios
 export const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10000,
+  timeout: 20000,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Summary
- increase axios timeout to 20s in frontend API client
- extend backend default timeout for house and RTP fetchers
- update WebSocket service to use new timeout
- document timeout variable in `.env.example`

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6873f3a87660832ea007605f4c828f19