### PR TITLE
Add WebSocket init data and frontend socket integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 - 2025-07-17: WebSocket agora recarrega periodicamente as casas de aposta para detectar novas entradas sem duplicar intervalos.
 - 2025-07-18: Corrigido carregamento de arquivos .proto no backend; script de build agora copia a pasta `src/proto` para `dist`.
 - 2025-07-19: Adicionados filtros de jogos por nome, provedor e RTP positivo/negativo na página `Games`.
+- 2025-07-20: WebSocket envia casas e jogos na inicialização e Games consome dados do socket.
 
 ## Estrutura de Banco de Dados
 

--- a/frontend/src/components/games/GameCard.tsx
+++ b/frontend/src/components/games/GameCard.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { Card } from '@/components/ui/Card'
 import { cn, convertSignedInt } from '@/lib/utils'
 import { useToast } from '@/hooks/useToast'
-import { Game, BettingHouse } from '@/types'
+import { HouseGame, BettingHouse } from '@/types'
 import { ArrowUpIcon, ArrowDownIcon } from 'lucide-react'
 
 interface GameCardProps {
-  game: Game
+  game: HouseGame
   house: BettingHouse
-  getRtp: (game: Game, houseId: number) => number
+  getRtp: (game: HouseGame, houseId: number) => number
   rtpClass: (value: number) => string
   className?: string
 }
@@ -27,7 +27,7 @@ export default function GameCard({ game, house, getRtp, rtpClass, className }: G
       className={cn('overflow-hidden cursor-pointer', className)}
     >
       <img
-        src={`data:image/webp;base64,${game.imageUrl}`}
+        src={`data:image/webp;base64,${game.imageUrl || ''}`}
         alt={game.name}
         className="w-full h-24 object-contain border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900"
       />

--- a/frontend/src/hooks/useRtpSocket.tsx
+++ b/frontend/src/hooks/useRtpSocket.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { BettingHouse, HouseGame } from '@/types'
 
 function adjustRtp(raw: number): number {
   const val = BigInt(raw)
@@ -17,27 +18,54 @@ export interface RtpUpdate {
 
 export function useRtpSocket() {
   const [updates, setUpdates] = useState<RtpUpdate[]>([])
+  const [houses, setHouses] = useState<BettingHouse[]>([])
+  const [houseGames, setHouseGames] = useState<Record<number, HouseGame[]>>({})
 
   useEffect(() => {
-    const wsUrl =
-      (import.meta as any).env.VITE_WS_URL || 'wss://rtp-api.zapchatbr.com/ws'
+    const meta = import.meta as unknown as { env: { VITE_WS_URL?: string } }
+    const wsUrl = meta.env.VITE_WS_URL || 'wss://rtp-api.zapchatbr.com/ws'
     const ws = new WebSocket(wsUrl)
 
     ws.onmessage = (event) => {
       try {
         const payload = JSON.parse(event.data)
-        if (payload.type === 'rtp') {
-          const adjusted = (payload.data as RtpUpdate[]).map((u) => ({
-            ...u,
-            rtp: adjustRtp(u.rtp),
-          }))
-          setUpdates((prev) => {
-            const map = new Map(prev.map((u) => [`${u.houseId}:${u.gameName}`, u]))
-            adjusted.forEach((u) => {
-              map.set(`${u.houseId}:${u.gameName}`, u)
+        switch (payload.type) {
+          case 'rtp': {
+            const adjusted = (payload.data as RtpUpdate[]).map((u) => ({
+              ...u,
+              rtp: adjustRtp(u.rtp),
+            }))
+            setUpdates((prev) => {
+              const map = new Map(prev.map((u) => [`${u.houseId}:${u.gameName}`, u]))
+              adjusted.forEach((u) => {
+                map.set(`${u.houseId}:${u.gameName}`, u)
+              })
+              return Array.from(map.values())
             })
-            return Array.from(map.values())
-          })
+            break
+          }
+          case 'init': {
+            const data = payload.data as { houses: BettingHouse[]; games: Record<number, HouseGame[]> }
+            setHouses(data.houses)
+            setHouseGames(data.games || {})
+            break
+          }
+          case 'houseAdded': {
+            const { house, games } = payload.data as { house: BettingHouse; games: HouseGame[] }
+            setHouses((prev) => [...prev.filter((h) => h.id !== house.id), house])
+            setHouseGames((prev) => ({ ...prev, [house.id]: games }))
+            break
+          }
+          case 'houseRemoved': {
+            const { houseId } = payload.data as { houseId: number }
+            setHouses((prev) => prev.filter((h) => h.id !== houseId))
+            setHouseGames((prev) => {
+              const copy = { ...prev }
+              delete copy[houseId]
+              return copy
+            })
+            break
+          }
         }
       } catch {
         // ignore
@@ -47,5 +75,5 @@ export function useRtpSocket() {
     return () => ws.close()
   }, [])
 
-  return updates
+  return { updates, houses, houseGames }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
 // Configuração base da API
-const API_BASE_URL =
-  (import.meta as any).env.VITE_API_URL || 'https://rtp-api.zapchatbr.com/api'
+const meta = import.meta as unknown as { env: { VITE_API_URL?: string } }
+const API_BASE_URL = meta.env.VITE_API_URL || 'https://rtp-api.zapchatbr.com/api'
 
 // Criar instância do axios
 export const api = axios.create({

--- a/frontend/src/pages/profile/Profile.tsx
+++ b/frontend/src/pages/profile/Profile.tsx
@@ -55,8 +55,8 @@ export default function ProfilePage() {
       const message =
         err instanceof Error &&
         'response' in err &&
-        typeof (err as any).response?.data?.error === 'string'
-          ? String((err as any).response.data.error)
+        typeof (err as { response?: { data?: { error?: string } } }).response?.data?.error === 'string'
+          ? String((err as { response?: { data?: { error?: string } } }).response!.data!.error)
           : 'Erro ao alterar senha'
       setError(message)
     } finally {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "es2020"],
+    "target": "es2020",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- send initial betting house and game data over WebSocket
- notify clients when houses are added or removed
- track houses and games in `useRtpSocket`
- consume socket data in Games page
- adjust card and profile components for new types
- update TypeScript target to ES2020
- document change in AGENTS.md

## Testing
- `npm test` in backend
- `npm run lint` and `npm run type-check` in frontend

------
https://chatgpt.com/codex/tasks/task_e_687513956830832ca580858ad908e17e