### PR TITLE
Remove REST call for house games

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@
 - Evitar duplicar componentes de layout; as páginas que já são embrulhadas pelo
   `Layout` nas rotas não devem importá-lo novamente. Isso previne headers
   duplicados.
+- Listagens de jogos das casas devem vir do serviço WebSocket (`useRtpSocket`),
+  não via requisições REST para `/games/house`.
 
 ### Histórico de Alterações
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -89,8 +89,6 @@ export const gamesApi = {
 
   getStats: () =>
     api.get('/games/stats'),
-
-  getHouseGames: (id: number) => api.get(`/games/house/${id}`),
 }
 
 // Funções de RTP


### PR DESCRIPTION
## Summary
- remove deprecated `getHouseGames` from `api.ts`
- clarify in `AGENTS.md` that house game lists come from the WebSocket

## Testing
- `npm test` in `backend`
- `npm run lint` in `backend`
- `yarn lint` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68751aeeb4f8832ca9306d632db65c9d