### PR TITLE
Add WebSocket reconnection logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Evitar duplicar componentes de layout; as páginas que já são embrulhadas pelo
   `Layout` nas rotas não devem importá-lo novamente. Isso previne headers
   duplicados.
+- O hook `useRtpSocket` deve reconectar automaticamente com backoff exponencial caso o WebSocket feche inesperadamente.
 
 ### Histórico de Alterações
 
@@ -23,6 +24,7 @@
 - 2025-07-18: Corrigido carregamento de arquivos .proto no backend; script de build agora copia a pasta `src/proto` para `dist`.
 - 2025-07-19: Adicionados filtros de jogos por nome, provedor e RTP positivo/negativo na página `Games`.
 - 2025-07-20: WebSocket envia casas e jogos na inicialização e Games consome dados do socket.
+- 2025-07-21: `useRtpSocket` agora reconecta automaticamente com backoff exponencial e limpa timers ao desmontar.
 
 ## Estrutura de Banco de Dados
 

--- a/frontend/src/hooks/useRtpSocket.tsx
+++ b/frontend/src/hooks/useRtpSocket.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { BettingHouse, HouseGame } from '@/types'
 
 function adjustRtp(raw: number): number {
@@ -20,59 +20,94 @@ export function useRtpSocket() {
   const [updates, setUpdates] = useState<RtpUpdate[]>([])
   const [houses, setHouses] = useState<BettingHouse[]>([])
   const [houseGames, setHouseGames] = useState<Record<number, HouseGame[]>>({})
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const attemptRef = useRef(0)
 
   useEffect(() => {
     const meta = import.meta as unknown as { env: { VITE_WS_URL?: string } }
     const wsUrl = meta.env.VITE_WS_URL || 'wss://rtp-api.zapchatbr.com/ws'
-    const ws = new WebSocket(wsUrl)
+    let ws: WebSocket | null = null
+    let unmounted = false
 
-    ws.onmessage = (event) => {
-      try {
-        const payload = JSON.parse(event.data)
-        switch (payload.type) {
-          case 'rtp': {
-            const adjusted = (payload.data as RtpUpdate[]).map((u) => ({
-              ...u,
-              rtp: adjustRtp(u.rtp),
-            }))
-            setUpdates((prev) => {
-              const map = new Map(prev.map((u) => [`${u.houseId}:${u.gameName}`, u]))
-              adjusted.forEach((u) => {
-                map.set(`${u.houseId}:${u.gameName}`, u)
+    const connect = () => {
+      if (reconnectTimer.current) {
+        clearTimeout(reconnectTimer.current)
+      }
+
+      ws = new WebSocket(wsUrl)
+
+      ws.onopen = () => {
+        attemptRef.current = 0
+      }
+
+      ws.onmessage = (event) => {
+        try {
+          const payload = JSON.parse(event.data)
+          switch (payload.type) {
+            case 'rtp': {
+              const adjusted = (payload.data as RtpUpdate[]).map((u) => ({
+                ...u,
+                rtp: adjustRtp(u.rtp),
+              }))
+              setUpdates((prev) => {
+                const map = new Map(prev.map((u) => [`${u.houseId}:${u.gameName}`, u]))
+                adjusted.forEach((u) => {
+                  map.set(`${u.houseId}:${u.gameName}`, u)
+                })
+                return Array.from(map.values())
               })
-              return Array.from(map.values())
-            })
-            break
+              break
+            }
+            case 'init': {
+              const data = payload.data as { houses: BettingHouse[]; games: Record<number, HouseGame[]> }
+              setHouses(data.houses)
+              setHouseGames(data.games || {})
+              break
+            }
+            case 'houseAdded': {
+              const { house, games } = payload.data as { house: BettingHouse; games: HouseGame[] }
+              setHouses((prev) => [...prev.filter((h) => h.id !== house.id), house])
+              setHouseGames((prev) => ({ ...prev, [house.id]: games }))
+              break
+            }
+            case 'houseRemoved': {
+              const { houseId } = payload.data as { houseId: number }
+              setHouses((prev) => prev.filter((h) => h.id !== houseId))
+              setHouseGames((prev) => {
+                const copy = { ...prev }
+                delete copy[houseId]
+                return copy
+              })
+              break
+            }
           }
-          case 'init': {
-            const data = payload.data as { houses: BettingHouse[]; games: Record<number, HouseGame[]> }
-            setHouses(data.houses)
-            setHouseGames(data.games || {})
-            break
-          }
-          case 'houseAdded': {
-            const { house, games } = payload.data as { house: BettingHouse; games: HouseGame[] }
-            setHouses((prev) => [...prev.filter((h) => h.id !== house.id), house])
-            setHouseGames((prev) => ({ ...prev, [house.id]: games }))
-            break
-          }
-          case 'houseRemoved': {
-            const { houseId } = payload.data as { houseId: number }
-            setHouses((prev) => prev.filter((h) => h.id !== houseId))
-            setHouseGames((prev) => {
-              const copy = { ...prev }
-              delete copy[houseId]
-              return copy
-            })
-            break
-          }
+        } catch {
+          // ignore
         }
-      } catch {
-        // ignore
+      }
+
+      ws.onerror = () => {
+        ws?.close()
+      }
+
+      ws.onclose = () => {
+        if (unmounted) return
+
+        attemptRef.current += 1
+        const delay = Math.min(30000, 1000 * 2 ** (attemptRef.current - 1))
+        reconnectTimer.current = setTimeout(connect, delay)
       }
     }
 
-    return () => ws.close()
+    connect()
+
+    return () => {
+      unmounted = true
+      ws?.close()
+      if (reconnectTimer.current) {
+        clearTimeout(reconnectTimer.current)
+      }
+    }
   }, [])
 
   return { updates, houses, houseGames }


### PR DESCRIPTION
## Summary
- handle onclose/onerror in useRtpSocket
- reconnect with exponential backoff and cleanup timers
- document reconnection strategy in AGENTS.md

## Testing
- `npm run lint` in frontend
- `npm run type-check` in frontend
- `npm run lint` in backend
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_68751af12638832ca54b2eeaf6731ce4