### PR TITLE
Document VERIFY_SSL env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@
 - Evitar duplicar componentes de layout; as páginas que já são embrulhadas pelo
   `Layout` nas rotas não devem importá-lo novamente. Isso previne headers
   duplicados.
+- A variável `VERIFY_SSL` controla a validação de certificados nas requisições HTTPS.
+  Desative (`VERIFY_SSL=false`) apenas em desenvolvimento para evitar riscos de segurança.
 
 ### Histórico de Alterações
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ cd backend
 npm install
 cp .env.example .env
 # Configure as variáveis no .env
+# Defina `VERIFY_SSL=false` caso precise ignorar certificados SSL (uso apenas em desenvolvimento)
 npm run migrate
 npm run seed
 npm run dev

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,6 @@ BCRYPT_ROUNDS=12
 # Tempo máximo de espera (ms) ao consultar APIs de jogos
 RTP_API_TIMEOUT_MS=20000
 
+# Defina para 'false' para ignorar certificados SSL. Use apenas em desenvolvimento
+VERIFY_SSL=true
+


### PR DESCRIPTION
## Summary
- document VERIFY_SSL flag in backend example env file
- explain how to disable SSL verification in README
- add note in AGENTS about using VERIFY_SSL=false only in dev

## Testing
- `npm test` in backend
- `npm run lint` in backend
- `npm run lint` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68751afdb248832ca965f11dd583724b