### PR TITLE
Fix docker-compose frontend port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,10 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
-      NEXT_PUBLIC_API_URL: http://localhost:3001/api
+      VITE_API_URL: http://backend:3001/api
+      VITE_WS_URL: ws://backend:3001/ws
     ports:
-      - "3000:3000"
+      - "3000:80"
     depends_on:
       - backend
     networks:


### PR DESCRIPTION
## Summary
- correct Docker Compose to map port 3000 to Nginx's port 80
- set VITE_API_URL and VITE_WS_URL env vars for frontend service

## Testing
- `npm run build` in frontend
- `npm test` in backend
- `npm run build` in backend

------
https://chatgpt.com/codex/tasks/task_e_687527752d08832ca75d7d521ccd17ed